### PR TITLE
Remove deprecated click method get_os_args

### DIFF
--- a/angreal/__init__.py
+++ b/angreal/__init__.py
@@ -30,7 +30,7 @@ __all__ = [
 
     # Click Utilities
     'echo', 'get_binary_stream', 'get_text_stream', 'open_file',
-    'format_filename', 'get_app_dir', 'get_os_args',
+    'format_filename', 'get_app_dir',
 
     # Angreal Utilities
     'get_angreal_path', 'import_from_file', 'win', 'warn', 'error',

--- a/angreal/decorators/__init__.py
+++ b/angreal/decorators/__init__.py
@@ -12,7 +12,7 @@ from click.decorators import pass_context, pass_obj, make_pass_decorator, \
 
 # Utilities
 from click.utils import echo, get_binary_stream, get_text_stream, open_file, \
-     format_filename, get_app_dir, get_os_args
+     format_filename, get_app_dir
 
 
 from angreal.integrations.virtual_env import venv_required

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -14,7 +14,7 @@ class TestUtils(unittest.TestCase):
                      argument, option, confirmation_option, password_option,
                      version_option, help_option,
                      echo, get_binary_stream, get_text_stream, open_file,
-                     format_filename, get_app_dir, get_os_args,
+                     format_filename, get_app_dir, 
                      get_angreal_path, import_from_file, win, warn, error,
                       VirtualEnv, Replay,Git,
                      venv_required,


### PR DESCRIPTION
Hi Dylan, this pull request is to remove the `get_os_args`, which has been deprecated from click. This is causing some of our builds to fail. Thank you