### PR TITLE
Replace "here" link with more descriptive link text

### DIFF
--- a/docs/content/tutorials/your-first-angreal.md
+++ b/docs/content/tutorials/your-first-angreal.md
@@ -3,7 +3,7 @@ title: Your First Angreal
 weight: 10
 ---
 
-{{% notice note %}}This project is available as part of the git repository[here](https://gitlab.com/dylanbstorey/angreal/tree/master/example).{{% /notice %}}
+{{% notice note %}}This project is available under the [example folder of the git repository](https://gitlab.com/dylanbstorey/angreal/tree/master/example).{{% /notice %}}
 
 This a very simple project for taking meeting minutes !
 


### PR DESCRIPTION
This was mostly because I noticed the lack of space between `repository` and `here`, but a personal bug-bear of mine is link text of "here" (as it's bad for screen readers.