### PR TITLE
2.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,6 @@ name: "Angreal Tests"
 on:
   push:
     branches:
-  pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
@@ -72,7 +70,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: pip install maturin angreal==2.0.0rc-1 pytest
+      - run: pip install maturin angreal pytest
       - run: angreal run-tests
   
   angreal-tests-windows:
@@ -89,7 +87,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: pip install maturin angreal==2.0.0rc-1 pytest
+      - run: pip install maturin angreal pytest
       - run: angreal run-tests
 
   maturin-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: "Angreal Tests"
 
 on:
   push:
-    branches: [main]
+    branches:
   pull_request:
     branches: [main]
 
@@ -58,9 +58,26 @@ jobs:
   
 
 
-  angreal-tests:
-    name: "angreal run-tests"
+  angreal-tests-linux:
+    name: "angreal run-tests linux"
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.65.0
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: pip install maturin angreal==2.0.0rc-1 pytest
+      - run: angreal run-tests
+  
+  angreal-tests-windows:
+    name: "angreal run-tests windows"
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,8 +65,6 @@ jobs:
         platform:
           - target: x64
             interpreter: 3.7 3.8 3.9 3.10 3.11 
-          - target: x86
-            interpreter: 3.7 3.8 3.9 3.10 3.11
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $: angreal init https://github.com/angreal/python
 ```
 --- 
 
+
 ## What is it?
 
 Angreal is an attempt to solve two problems that I was running into in

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -30,7 +30,7 @@ enableMissingTranslationPlaceholders = false
   # Set this to true to disable this behavior (some proxies don't handle well this optimization)
   disableAssetsBusting = false
   # Set this to true to disable copy-to-clipboard button for inline code.
-  disableInlineCopyToClipBoard = false
+  disableInlineCopyToClipBoard = true
   # A title for shortcuts in menu is set by default. Set this to true to disable it.
   disableShortcutsTitle = false
   # If set to false, a Home button will appear below the search bar on the menu.

--- a/docs/content/api_reference/_index.md
+++ b/docs/content/api_reference/_index.md
@@ -14,6 +14,4 @@ before, you should be pretty comfortable already.
 [Cargo Docs](https://docs.rs/angreal)
 
 ## Python API Reference
-
-Coming soon.
-<!-- TODO ! -->
+[Python Docs](py_angreal)

--- a/docs/content/api_reference/_index.md
+++ b/docs/content/api_reference/_index.md
@@ -3,6 +3,12 @@ title: API Reference
 weight: 50
 ---
 
+## Templating Language Reference
+Templating for this project is provided by the rust crate [Tera](https://tera.netlify.app/).
+
+Full [documentantion](https://tera.netlify.app/docs/) is here, but if you've ever used the python templating (jina2)[https://jinja.palletsprojects.com/en/3.1.x/]
+before, you should be pretty comfortable already.
+
 ## Rust API Reference
 
 [Cargo Docs](https://docs.rs/angreal)

--- a/docs/content/api_reference/py_angreal.md
+++ b/docs/content/api_reference/py_angreal.md
@@ -1,0 +1,69 @@
+---
+title : Python API Refence
+---
+Angreal's Python API
+
+---
+## Decorators:
+
+##### command(**name**: str=*None*, **about**: str=*""*, **long_about**: str=*""*, ****attrs**) -> None:
+> decorator that identifies a function as an angreal task
+```python
+import angreal
+
+@angreal.command(name='test-command')
+def noop_func():
+    pass
+```
+
+### Args:
+- name (str, optional): the name to be used to invoke a task. Defaults to the function name.  
+- about (str, optional): A short description of what the task does. Defaults to "".
+- long_about (str, optional): A longer description of what the task does. Defaults to the docstring on the decorated function.
+
+    
+
+
+##### argument(**name**, **python_type**: str=*"str"*, **takes_value**: bool=*True*, **default_value**: str=*None*, **require_equals**: bool=*None*, **multiple_values**: bool=*None*, **number_of_values**: int=*None*, **max_values**: int=*None*, **min_values**: int=*None*, **short**: str=*None*, **long**: str=*None*, **long_help**: str=*None*, **help**: str=*None*, **required**: bool=*None*, ****kwargs**) -> None:
+> decorator that adds an argument to an angreal task
+
+```python
+import angreal
+
+@angreal.command(name='test-command')
+@angreal.argument(name='noop_arg')
+def noop_func(noop_arg):
+    pass
+
+```
+### Args:
+- name (str): the argument name, must match a corresponding function argument
+- python_type (str, optional): the python type to pass the value as. Must be one of ("str","int","float") . Defaults to "str".
+- takes_value (bool, optional): doest the argument consume a trailing value. Defaults to True.
+- default_value (str, optional): The default value to apply if none is provided. Defaults to None.
+- require_equals (bool, optional): The consumed value requires an equal sign (i.e.`--arg=value`). Defaults to None.
+- multiple_values (bool, optional): The argument takes multiple values. Defaults to None.
+- number_of_values (int, optional): The argument takes a specific number of values. Defaults to None.
+- max_values (int, optional): The argument takes at most X values. Defaults to None.
+- min_values (int, optional): The argument takes at least X values. Defaults to None.
+- short (str, optional): The short (single characeter) flag for the argument (i.e. `-i in the cli` would be `i`). Defaults to None.
+- long (str, optional): The short (single word) flag for the argument (i.e. `--information` in the clie would be `information`). Defaults  to None.
+- long_help (str, optional): The help message to display with "long help" is requested with `--help`. Defaults to None.
+- help (str, optional): The help message to display when help is requested via `-h`. Defaults to None.
+- required (bool, optional): Whether the argument is required or not. Defaults to None.
+    
+
+
+##### get_root() -> str:
+> get the path to the root of the current angreal project.
+
+```python
+import angreal
+
+@angreal.command(name='test-command')
+@angreal.argument(name='noop_arg')
+def noop_func(noop_arg):
+    print(angreal.get_root())
+    pass
+```
+

--- a/docs/content/api_reference/py_angreal.md
+++ b/docs/content/api_reference/py_angreal.md
@@ -1,5 +1,5 @@
 ---
-title : Python API Refence
+title : Python API Reference
 ---
 Angreal's Python API
 
@@ -46,7 +46,7 @@ def noop_func(noop_arg):
 - number_of_values (int, optional): The argument takes a specific number of values. Defaults to None.
 - max_values (int, optional): The argument takes at most X values. Defaults to None.
 - min_values (int, optional): The argument takes at least X values. Defaults to None.
-- short (str, optional): The short (single characeter) flag for the argument (i.e. `-i in the cli` would be `i`). Defaults to None.
+- short (str, optional): The short (single character) flag for the argument (i.e. `-i in the cli` would be `i`). Defaults to None.
 - long (str, optional): The short (single word) flag for the argument (i.e. `--information` in the clie would be `information`). Defaults  to None.
 - long_help (str, optional): The help message to display with "long help" is requested with `--help`. Defaults to None.
 - help (str, optional): The help message to display when help is requested via `-h`. Defaults to None.

--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -3,15 +3,15 @@ title: Contributing
 weight: 50
 ---
 
-Angreal is hosted on [gitlab](https://gitlab.com/angreal/angreal).
+Angreal is hosted on [gitlhub](https://github.com/angreal/angreal).
 
 If you have questions, concerns, bug reports, or suggestions please feel
-free to open an [issue](https://gitlab.com/angreal/angreal/issues/new),
-I\'ll do my best to get it addressed at any time.
+free to open an [issue](https://github.com/angreal/angreal/issues),
+I'll do my best to get it addressed.
 
-If you\'d like to contribute back to angreal\'s code base (or
-documentation!) feel free to submit a [merge
-request](https://gitlab.com/angreal/angreal/merge_requests/new).
+If you'd like to contribute back to angreal's code base (or
+documentation!) feel free to submit a [pull
+request](https://github.com/angreal/angreal/pulls).
 
 Before submitting a merge request, it would be best if you open a new
 issue that outlines what the problem you wish to solve is (and perhaps
@@ -19,6 +19,24 @@ see if anyone else is working on it).
 
 ## Development setup
 
+Angreal uses angreal! Tasks can be confidently run on :
+- linux
+- Windows WSL
+- MacOSX
+
+
 1. `pip install angreal`, install angreal for executing our defined tasks
 1. `angreal bootstrap-dev`, setup your environment
 1. `angreal run-tests`, run our test suite
+
+
+### Windows Development Support
+
+I did not have windows in mind when writing initial angreal tasks, they may (probably) won't work 
+well out of the box.
+
+1. When running `maturin develop` you may see failures in the build chain due to OpenSSL not being installed. Installing [StrawberryPerl](https://strawberryperl.com/)
+SHOULD take care of that for you. 
+
+2. Tests can be run via `cargo test` and `pytest`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,21 @@ build-backend = "maturin"
 name = "angreal"
 requires-python = ">=3.7"
 classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
     "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development :: Libraries :: Python Modules",    
 ]
 
 

--- a/python/angreal/__init__.py
+++ b/python/angreal/__init__.py
@@ -1,4 +1,9 @@
+"""
+Angreal's Python API
+
+"""
 from .angreal import *
+from .angreal import get_root as _get_root
 
 
 __doc__ = angreal.__doc__
@@ -6,9 +11,15 @@ if hasattr(angreal, "__all__"):
     __all__ = angreal.__all__
 
 
-def command(name=None, about="", long_help="", **attrs):
-    """
-    The command decorator, used to register a user defined function as a subcommand for angreal to execute.
+
+def command(name:str=None, about: str="", long_about:str="", **attrs) ->None :   
+    """decorator that identifies a function as an angreal task
+
+    Args:
+        name (str, optional): the name to be used to invoke a task. Defaults to the function name.  
+        about (str, optional): A short description of what the task does. Defaults to "".
+        long_about (str, optional): A longer description of what the task does. Defaults to the docstring on the decorated function.
+
     """
     _wrapped = None
 
@@ -17,12 +28,12 @@ def command(name=None, about="", long_help="", **attrs):
         name = _wrapped.__name__.lower().replace("_", "-")
 
 
-    def decorator(f):
+    def decorator(f, long_about=None):
 
         if not hasattr(f, "__arguments"):
             f.__arguments = []
                         
-                        
+        long_about = long_about or f.__doc__                        
         angreal.Command(name=name, about=about, long_about=f.__doc__, func=f)
 
         for arg in f.__arguments :
@@ -31,18 +42,44 @@ def command(name=None, about="", long_help="", **attrs):
         return f
 
     if _wrapped is not None:
-        return decorator(_wrapped)
+        return decorator(_wrapped,long_about=long_about)
 
     return decorator
 
 
-def argument(name, **kwargs):
-    """Register an argument as part of a command
+def argument(name,    
+        python_type: str = "str",
+        takes_value: bool = True,
+        default_value: str = None,
+        require_equals: bool = None,
+        multiple_values: bool = None,
+        number_of_values: int = None,
+        max_values: int = None,
+        min_values: int = None,
+        short: str = None,
+        long: str = None,
+        long_help: str = None,
+        help: str = None,
+        required: bool = None, 
+        **kwargs):
+    """decorator that adds an argument to an angreal task
 
     Args:
-            name (_type_): _description_
+        name (str): the argument name, must match a corresponding function argument
+        python_type (str, optional): the python type to pass the value as. Must be one of ("str","int","float") . Defaults to "str".
+        takes_value (bool, optional): doest the argument consume a trailing value. Defaults to True.
+        default_value (str, optional): The default value to apply if none is provided. Defaults to None.
+        require_equals (bool, optional): The consumed value requires an equal sign (i.e.`--arg=value`). Defaults to None.
+        multiple_values (bool, optional): The argument takes multiple values. Defaults to None.
+        number_of_values (int, optional): The argument takes a specific number of values. Defaults to None.
+        max_values (int, optional): The argument takes at most X values. Defaults to None.
+        min_values (int, optional): The argument takes at least X values. Defaults to None.
+        short (str, optional): The short (single characeter) flag for the argument (i.e. `-i in the cli` would be `i`). Defaults to None.
+        long (str, optional): The short (single word) flag for the argument (i.e. `--information` in the clie would be `information`). Defaults to None.
+        long_help (str, optional): The help message to display with "long help" is requested with `--help`. Defaults to None.
+        help (str, optional): The help message to display when help is requested via `-h`. Defaults to None.
+        required (bool, optional): Whether the argument is required or not. Defaults to None.
     """
-
     def decorator(f):
         keyword_args = kwargs.copy()
 
@@ -55,6 +92,9 @@ def argument(name, **kwargs):
 
     return decorator
 
+
+def get_root():
+    return _get_root()
 
 def main():
     angreal.main()

--- a/python/angreal/__init__.py
+++ b/python/angreal/__init__.py
@@ -74,7 +74,7 @@ def argument(name,
         number_of_values (int, optional): The argument takes a specific number of values. Defaults to None.
         max_values (int, optional): The argument takes at most X values. Defaults to None.
         min_values (int, optional): The argument takes at least X values. Defaults to None.
-        short (str, optional): The short (single characeter) flag for the argument (i.e. `-i in the cli` would be `i`). Defaults to None.
+        short (str, optional): The short (single character) flag for the argument (i.e. `-i in the cli` would be `i`). Defaults to None.
         long (str, optional): The short (single word) flag for the argument (i.e. `--information` in the clie would be `information`). Defaults to None.
         long_help (str, optional): The help message to display with "long help" is requested with `--help`. Defaults to None.
         help (str, optional): The help message to display when help is requested via `-h`. Defaults to None.

--- a/src/init.rs
+++ b/src/init.rs
@@ -107,6 +107,11 @@ pub fn init(template: &str, force: bool, take_inputs: bool) {
             function.call0(py).unwrap();
         });
     }
+
+    println!(
+        "Angreal template ({}) successfully rendered !",
+        template.to_string_lossy()
+    );
 }
 
 fn get_scheme(u: &str) -> Result<String, ()> {

--- a/src/py_logger.rs
+++ b/src/py_logger.rs
@@ -54,7 +54,7 @@ fn host_log(record: &PyAny) -> PyResult<()> {
             .metadata(error_metadata)
             .args(format_args!("{}", &message))
             .line(Some(lineno))
-            .file(Some("app.rs"))
+            .file(Some("angreal task"))
             .module_path(Some(&pathname))
             .build(),
     );

--- a/src/task.rs
+++ b/src/task.rs
@@ -88,7 +88,6 @@ impl AngrealArg {
         number_of_values = "None",
         max_values = "None",
         min_values = "None",
-        python_type = "None",
         short = "None",
         long = "None",
         long_help = "None",


### PR DESCRIPTION
# 2.0.1

- Adds additional windows based tests to our CI/CD pipeline
- Adds a positive message on successful execution of `angreal init`
- Introduces a number of debug level messages into `init.rs`
- Solves a bug in windows where the carriage return was causing `fs::make_dir` to fail
- Added doc strings and concrete args/kwargs to the python api as needed to ensure we have the ability to extract to documentation.  
