### PR TITLE
update functions to accept a tomloverride (#87)

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -48,6 +48,12 @@ fn add_init_subcommand(app: App<'static>) -> App<'static> {
                     .takes_value(false)
                     .help("Use default values provided in the angreal.toml."),
             )
+            .arg(
+                Arg::new("values_file")
+                    .long("--values")
+                    .takes_value(true)
+                    .help("Provide Values to template, bypassing template toml."),
+            )
             .arg(Arg::new("template").takes_value(true).required(true).help(
                 "The template to use. Either a pre-downloaded template name, or url to a git repo.",
             )),

--- a/src/init.rs
+++ b/src/init.rs
@@ -24,9 +24,10 @@ use toml::Value;
 use log::{debug, error};
 
 /// Initialize a new project by rendering a template.
-pub fn init(template: &str, force: bool, take_inputs: bool) {
+pub fn init(template: &str, force: bool, take_inputs: bool, values_file: Option<&str>) {
     let angreal_home = create_home_dot_angreal();
     let template_type = get_scheme(template).unwrap();
+
     debug!("Got template type {:?} for {:?}.", template_type, template);
 
     debug!("Template is of type {:?}", template_type.as_str());
@@ -47,7 +48,7 @@ pub fn init(template: &str, force: bool, take_inputs: bool) {
         }
     };
 
-    let rendered_dot_angreal_path = render_template(Path::new(&template), take_inputs, force);
+    let rendered_dot_angreal_path = render_template(Path::new(&template), take_inputs, force, values_file);
 
     let mut rendered_angreal_init = Path::new(&rendered_dot_angreal_path).to_path_buf();
     rendered_angreal_init.push("init.py");
@@ -224,20 +225,15 @@ fn create_home_dot_angreal() -> PathBuf {
 }
 
 /// render the provided angreal template path
-fn render_template(path: &Path, take_input: bool, force: bool) -> String {
-    // Verify the provided template path is minimially compliant.
-    let mut toml = path.to_path_buf();
-    toml.push(Path::new("angreal.toml"));
-    debug!("angreal.toml should be at {:?}", toml);
-    if toml.is_file().not() {
-        error!(
-            "`angreal.toml` not found where expected {:}",
-            toml.display()
-        );
-    }
-
+fn render_template(path: &Path, take_input: bool, force: bool, values_file: Option<&str>) -> String {
     // create a tera context from the toml file interactively.
-    let context = repl_context_from_toml(toml, take_input);
+    let context = if values_file.is_some() {
+        let values_file = Path::new(values_file);
+        repl_context_from_toml(values_file.to_path_buf(), false)
+    }
+    else {
+        repl_context_from_toml(path.to_path_buf(), take_input)
+    };
     let ctx = context.clone();
 
     // render the provided template directory
@@ -271,16 +267,18 @@ fn render_template(path: &Path, take_input: bool, force: bool) -> String {
 mod tests {
 
     use std::ops::Not;
-    use std::path::{Path, PathBuf};
-    use std::{env, fs};
+    use std::{
+        fs::{self, File},
+        path::{Path, PathBuf},
+    };
     use tempfile::tempdir;
-
     #[test]
     fn test_init_from_git() {
         crate::init::init(
             "https://github.com/angreal/angreal_test_template.git",
             true,
             false,
+            None,
         );
         let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         rendered_root.push(Path::new("angreal_test_project"));
@@ -345,13 +343,14 @@ mod tests {
             "https://github.com/angreal/angreal_test_template.git",
             true,
             false,
+            None,
         );
         // clean up rendered
         let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         rendered_root.push(Path::new("angreal_test_project"));
         let _ = fs::remove_dir_all(&rendered_root);
         // use the long version
-        crate::init::init("angreal/angreal_test_template", true, false);
+        crate::init::init("angreal/angreal_test_template", true, false, Some("template/test/angreal.toml"));
         let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         rendered_root.push(Path::new("angreal_test_project"));
         let _ = fs::remove_dir_all(&rendered_root);
@@ -361,7 +360,7 @@ mod tests {
     #[test]
     fn test_init_short() {
         // clone
-        crate::init::init("angreal_test_template", true, false);
+        crate::init::init("angreal_test_template", true, false, None);
         let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         rendered_root.push(Path::new("angreal_test_project"));
         let _ = fs::remove_dir_all(&rendered_root);
@@ -372,7 +371,7 @@ mod tests {
     fn test_render_template() {
         let mut template_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         template_root.push(Path::new("tests/common/test_assets/test_template"));
-        crate::init::render_template(&template_root, false, true);
+        crate::init::render_template(&template_root, false, true, None);
 
         let mut angreal_toml = template_root.clone();
         angreal_toml.push("angreal.toml");
@@ -434,4 +433,5 @@ mod tests {
         let str_schema = crate::init::get_scheme(str_str);
         assert_eq!(str_schema.unwrap(), "file");
     }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,13 +89,15 @@ fn main() -> PyResult<()> {
     debug!("Log verbosity set to level: {}", verbosity);
 
     match sub_command.subcommand() {
-        Some(("init", _sub_matches)) => 
-            init::init(
+        Some(("init", _sub_matches)) => init::init(
             _sub_matches.value_of("template").unwrap(),
             _sub_matches.is_present("force"),
             _sub_matches.is_present("defaults").not(),
-            Some(_sub_matches.value_of("values_file").unwrap()),
-        
+            if _sub_matches.is_present("values_file") {
+                Some(_sub_matches.value_of("values_file").unwrap())
+            } else {
+                None
+            },
         ),
         Some((task, sub_m)) => {
             if !in_angreal_project {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,10 +89,13 @@ fn main() -> PyResult<()> {
     debug!("Log verbosity set to level: {}", verbosity);
 
     match sub_command.subcommand() {
-        Some(("init", _sub_matches)) => init::init(
+        Some(("init", _sub_matches)) => 
+            init::init(
             _sub_matches.value_of("template").unwrap(),
             _sub_matches.is_present("force"),
             _sub_matches.is_present("defaults").not(),
+            Some(_sub_matches.value_of("values_file").unwrap()),
+        
         ),
         Some((task, sub_m)) => {
             if !in_angreal_project {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,7 +54,7 @@ pub fn repl_context_from_toml(toml_path: PathBuf, take_input: bool) -> Context {
         } else {
             v.clone()
         };
-
+        
         let input = if take_input {
             print!("{k}? [{value}]: ");
             read!("{}\n")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,7 +54,7 @@ pub fn repl_context_from_toml(toml_path: PathBuf, take_input: bool) -> Context {
         } else {
             v.clone()
         };
-        
+
         let input = if take_input {
             print!("{k}? [{value}]: ");
             read!("{}\n")

--- a/tests/common/test_assets/values.toml
+++ b/tests/common/test_assets/values.toml
@@ -1,0 +1,4 @@
+key_1 = "values_key"
+key_2 = 2
+folder_variable = "folder_name"
+variable_text = '{{ folder_variable | replace(from="_",to="-") }}'


### PR DESCRIPTION
Moore would like to be able to provide a `toml` file with pre-filled out values to the CLI to bypass the REPL style collection while also allowing for something besides the "defaults" that get brought along if you do nothing.


`angreal init <template name> --values values.toml`  should run w/o interaction and simple replace the values in the template with the values in the `values.toml` file. 