### PR TITLE
  feat: enhance command metadata and MCP integration

### DIFF
--- a/.angreal/task_dev.py
+++ b/.angreal/task_dev.py
@@ -10,7 +10,12 @@ def is_program_available(program_name):
     return shutil.which(program_name) is not None
 
 @dev()
-@angreal.command(name="check-deps", about="check system dependencies")
+@angreal.command(
+    name="check-deps", 
+    about="Verify required development tools are installed",
+    when_to_use=["Setting up development environment", "Troubleshooting build issues", "Before running documentation or build tasks"],
+    when_not_to_use=["During normal development workflow", "When all dependencies are known to be installed"]
+)
 def check_system_dependencies():
     """
     Check for required system-level dependencies

--- a/.angreal/task_dev.py
+++ b/.angreal/task_dev.py
@@ -11,10 +11,17 @@ def is_program_available(program_name):
 
 @dev()
 @angreal.command(
-    name="check-deps", 
+    name="check-deps",
     about="Verify required development tools are installed",
-    when_to_use=["Setting up development environment", "Troubleshooting build issues", "Before running documentation or build tasks"],
-    when_not_to_use=["During normal development workflow", "When all dependencies are known to be installed"]
+    when_to_use=[
+        "Setting up development environment",
+        "Troubleshooting build issues",
+        "Before running documentation or build tasks"
+    ],
+    when_not_to_use=[
+        "During normal development workflow",
+        "When all dependencies are known to be installed"
+    ]
 )
 def check_system_dependencies():
     """

--- a/.angreal/task_docs.py
+++ b/.angreal/task_docs.py
@@ -81,10 +81,17 @@ def _integrate_rustdoc():
 
 @docs()
 @angreal.command(
-    name="clean", 
+    name="clean",
     about="Clean documentation build artifacts and cache",
-    when_to_use=["Before fresh documentation builds", "When build artifacts are corrupted", "During documentation troubleshooting"],
-    when_not_to_use=["During normal development", "When incremental builds are sufficient"]
+    when_to_use=[
+        "Before fresh documentation builds",
+        "When build artifacts are corrupted",
+        "During documentation troubleshooting"
+    ],
+    when_not_to_use=[
+        "During normal development",
+        "When incremental builds are sufficient"
+    ]
 )
 def clean():
     """Clean the documentation build directory."""
@@ -95,8 +102,15 @@ def clean():
 @angreal.command(
     name="serve",
     about="Start local documentation server with live reload",
-    when_to_use=["During documentation writing", "For previewing documentation changes", "When reviewing documentation locally"],
-    when_not_to_use=["In production environments", "For final documentation builds"]
+    when_to_use=[
+        "During documentation writing",
+        "For previewing documentation changes",
+        "When reviewing documentation locally"
+    ],
+    when_not_to_use=[
+        "In production environments",
+        "For final documentation builds"
+    ]
 )
 @angreal.argument(
     name="prod",
@@ -154,7 +168,11 @@ def serve(prod: bool = False):
 @angreal.command(
     name="build",
     about="Build production documentation site with Rust API docs",
-    when_to_use=["For production deployments", "Before releasing documentation", "For final documentation review"],
+    when_to_use=[
+        "For production deployments",
+        "Before releasing documentation",
+        "For final documentation review"
+    ],
     when_not_to_use=["During active documentation writing", "For quick local previews"]
 )
 @angreal.argument(

--- a/.angreal/task_docs.py
+++ b/.angreal/task_docs.py
@@ -80,7 +80,12 @@ def _integrate_rustdoc():
 
 
 @docs()
-@angreal.command(name="clean", about="clean the documentation build directory")
+@angreal.command(
+    name="clean", 
+    about="Clean documentation build artifacts and cache",
+    when_to_use=["Before fresh documentation builds", "When build artifacts are corrupted", "During documentation troubleshooting"],
+    when_not_to_use=["During normal development", "When incremental builds are sufficient"]
+)
 def clean():
     """Clean the documentation build directory."""
     return _clean_docs()
@@ -89,7 +94,9 @@ def clean():
 @docs()
 @angreal.command(
     name="serve",
-    about="serve the documentation site locally, by default building draft documents."
+    about="Start local documentation server with live reload",
+    when_to_use=["During documentation writing", "For previewing documentation changes", "When reviewing documentation locally"],
+    when_not_to_use=["In production environments", "For final documentation builds"]
 )
 @angreal.argument(
     name="prod",
@@ -146,7 +153,9 @@ def serve(prod: bool = False):
 @docs()
 @angreal.command(
     name="build",
-    about="build the documentation site, by default excluding draft documents."
+    about="Build production documentation site with Rust API docs",
+    when_to_use=["For production deployments", "Before releasing documentation", "For final documentation review"],
+    when_not_to_use=["During active documentation writing", "For quick local previews"]
 )
 @angreal.argument(
     name="draft",

--- a/.angreal/task_tests.py
+++ b/.angreal/task_tests.py
@@ -12,10 +12,17 @@ test = angreal.command_group(name="test", about="commands for testing the"
 
 @test()
 @angreal.command(
-    name="all", 
+    name="all",
     about="Run complete test suite (Python, Rust, completion)",
-    when_to_use=["Before major releases", "After significant changes", "For comprehensive validation"],
-    when_not_to_use=["During rapid development cycles", "When running specific test types"]
+    when_to_use=[
+        "Before major releases",
+        "After significant changes",
+        "For comprehensive validation"
+    ],
+    when_not_to_use=[
+        "During rapid development cycles",
+        "When running specific test types"
+    ]
 )
 def all_tests():
     """
@@ -37,9 +44,13 @@ def all_tests():
 
 @test()
 @angreal.command(
-    name="python", 
+    name="python",
     about="Run Python unit tests with pytest in isolated environment",
-    when_to_use=["After Python code changes", "Before committing Python changes", "To verify Python functionality"],
+    when_to_use=[
+        "After Python code changes",
+        "Before committing Python changes",
+        "To verify Python functionality"
+    ],
     when_not_to_use=["When only Rust code changed", "During Rust development cycles"]
 )
 def python_tests():
@@ -82,10 +93,17 @@ def python_tests():
 
 @test()
 @angreal.command(
-    name="rust", 
+    name="rust",
     about="Run Rust unit and integration tests with cargo",
-    when_to_use=["After Rust code changes", "Before committing Rust changes", "To verify core functionality"],
-    when_not_to_use=["When only Python code changed", "During Python development cycles"]
+    when_to_use=[
+        "After Rust code changes",
+        "Before committing Rust changes",
+        "To verify core functionality"
+    ],
+    when_not_to_use=[
+        "When only Python code changed",
+        "During Python development cycles"
+    ]
 )
 @angreal.argument(
     name="test_filter",
@@ -155,8 +173,15 @@ def unit_rust_tests():
 @angreal.command(
     name="completion",
     about="Run shell completion tests for bash and zsh",
-    when_to_use=["After modifying completion logic", "Before releases", "When testing shell integration"],
-    when_not_to_use=["During core functionality development", "When completion is not affected"]
+    when_to_use=[
+        "After modifying completion logic",
+        "Before releases",
+        "When testing shell integration"
+    ],
+    when_not_to_use=[
+        "During core functionality development",
+        "When completion is not affected"
+    ]
 )
 @angreal.argument(
     name="shell",

--- a/.angreal/task_tests.py
+++ b/.angreal/task_tests.py
@@ -106,12 +106,6 @@ def python_tests():
     ]
 )
 @angreal.argument(
-    name="test_filter",
-    help="filter tests by name pattern",
-    required=False,
-    takes_value=True
-)
-@angreal.argument(
     name="unit_only",
     long="unit-only",
     help="run only unit tests",

--- a/.angreal/task_tests.py
+++ b/.angreal/task_tests.py
@@ -11,7 +11,12 @@ test = angreal.command_group(name="test", about="commands for testing the"
                              " application and library")
 
 @test()
-@angreal.command(name="all", about="run all tests")
+@angreal.command(
+    name="all", 
+    about="Run complete test suite (Python, Rust, completion)",
+    when_to_use=["Before major releases", "After significant changes", "For comprehensive validation"],
+    when_not_to_use=["During rapid development cycles", "When running specific test types"]
+)
 def all_tests():
     """
     Run all tests: Python, Rust (unit + integration), and completion tests
@@ -31,7 +36,12 @@ def all_tests():
 
 
 @test()
-@angreal.command(name="python", about="run pytest unit tests")
+@angreal.command(
+    name="python", 
+    about="Run Python unit tests with pytest in isolated environment",
+    when_to_use=["After Python code changes", "Before committing Python changes", "To verify Python functionality"],
+    when_not_to_use=["When only Rust code changed", "During Rust development cycles"]
+)
 def python_tests():
     """
     Run the Python unit tests in isolated environment
@@ -71,7 +81,18 @@ def python_tests():
             exit(result.returncode)
 
 @test()
-@angreal.command(name="rust", about="run cargo unit and integration tests")
+@angreal.command(
+    name="rust", 
+    about="Run Rust unit and integration tests with cargo",
+    when_to_use=["After Rust code changes", "Before committing Rust changes", "To verify core functionality"],
+    when_not_to_use=["When only Python code changed", "During Python development cycles"]
+)
+@angreal.argument(
+    name="test_filter",
+    help="filter tests by name pattern",
+    required=False,
+    takes_value=True
+)
 @angreal.argument(
     name="unit_only",
     long="unit-only",
@@ -131,7 +152,12 @@ def unit_rust_tests():
 
 
 @test()
-@angreal.command(name="completion", about="run all shell completion tests")
+@angreal.command(
+    name="completion",
+    about="Run shell completion tests for bash and zsh",
+    when_to_use=["After modifying completion logic", "Before releases", "When testing shell integration"],
+    when_not_to_use=["During core functionality development", "When completion is not affected"]
+)
 @angreal.argument(
     name="shell",
     long="shell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "angreal"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-only"
 name = "angreal"
 readme = "README.md"
 repository = "https://github.com/angreal/angreal"
-version = "2.4.1"
+version = "2.4.2"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/docs/content/how-to-guides/create-a-task.md
+++ b/docs/content/how-to-guides/create-a-task.md
@@ -17,7 +17,7 @@ weight: 10
 import angreal
 
 @angreal.command(
-    name='command-name', 
+    name='command-name',
     about='text-to-display',
     when_to_use=['During development', 'For testing features'],
     when_not_to_use=['In production deployments', 'When debugging']

--- a/docs/content/how-to-guides/create-a-task.md
+++ b/docs/content/how-to-guides/create-a-task.md
@@ -16,7 +16,21 @@ weight: 10
 ```python
 import angreal
 
-@angreal.command(name='command-name', about='text-to-display')
+@angreal.command(
+    name='command-name', 
+    about='text-to-display',
+    when_to_use=['During development', 'For testing features'],
+    when_not_to_use=['In production deployments', 'When debugging']
+)
 def command_function():
     return
 ```
+
+## MCP Integration Fields
+
+The `when_to_use` and `when_not_to_use` fields provide guidance for AI agents and tools about appropriate usage contexts:
+
+- **when_to_use**: List scenarios where this command is appropriate
+- **when_not_to_use**: List scenarios where this command should be avoided
+
+These fields enhance the machine-readable command tree output and improve AI agent decision-making.

--- a/docs/content/reference/cli/_index.md
+++ b/docs/content/reference/cli/_index.md
@@ -100,6 +100,17 @@ angreal tree
 angreal tree --json
 ```
 
+**MCP Integration:**
+
+The `tree` command is designed for integration with Model Context Protocol (MCP) servers and AI agents. It provides a machine-readable JSON schema that includes:
+
+- Project context (root directory, Angreal version)
+- Complete command hierarchy with full command paths
+- Usage guidance (`when_to_use` and `when_not_to_use` fields)
+- Parameter information with types and requirements
+
+This enables AI agents to understand available commands and make informed decisions about when and how to use them. The JSON output is optimized for MCP consumption and automated tooling integration.
+
 ### alias
 
 Create and manage command aliases for white-labeling Angreal.

--- a/docs/content/reference/python-api/commands/command_decorator.md
+++ b/docs/content/reference/python-api/commands/command_decorator.md
@@ -10,7 +10,7 @@ A decorator that identifies a function as an Angreal command.
 ## Signature
 
 ```python
-command(name=None, about="", long_about="", **attrs) -> None
+command(name=None, about="", long_about="", when_to_use=None, when_not_to_use=None, **attrs) -> None
 ```
 
 ## Example
@@ -18,7 +18,12 @@ command(name=None, about="", long_about="", **attrs) -> None
 ```python
 import angreal
 
-@angreal.command(name='test-command')
+@angreal.command(
+    name='test-command',
+    about='Run the test suite',
+    when_to_use=['After code changes', 'Before committing', 'During CI/CD'],
+    when_not_to_use=['In production environments', 'When tests are known to be broken']
+)
 def command_function():
     pass
 
@@ -30,3 +35,5 @@ def command_function():
 - **name** (str, optional): The name to be used to invoke a command. Defaults to the function name.
 - **about** (str, optional): A short description of what the command does. Defaults to "".
 - **long_about** (str, optional): A longer description of what the command does. Defaults to the docstring on the decorated function.
+- **when_to_use** (List[str], optional): List of scenarios when this command should be used. Used for AI agent guidance and documentation.
+- **when_not_to_use** (List[str], optional): List of scenarios when this command should not be used. Used for AI agent guidance and documentation.

--- a/docs/content/reference/python-api/commands/commands_guide.md
+++ b/docs/content/reference/python-api/commands/commands_guide.md
@@ -22,7 +22,12 @@ Here's a basic example of creating a command:
 ```python
 import angreal
 
-@angreal.command(name="hello", about="Say hello to someone")
+@angreal.command(
+    name="hello", 
+    about="Say hello to someone",
+    when_to_use=["For greeting users", "During initial setup"],
+    when_not_to_use=["In automated scripts", "During production deployment"]
+)
 @angreal.argument(name="name", long="name", takes_value=True, help="Name to greet")
 def hello_command(name="World"):
     """
@@ -51,7 +56,12 @@ dev = angreal.command_group(name="dev", about="Development commands")
 
 # Add a command to the group
 @dev()
-@angreal.command(name="build", about="Build the project")
+@angreal.command(
+    name="build", 
+    about="Build the project",
+    when_to_use=["After code changes", "Before testing", "During development"],
+    when_not_to_use=["In production environments", "Without code changes"]
+)
 def build_command():
     """
     Build the project for development.

--- a/docs/content/reference/python-api/commands/commands_guide.md
+++ b/docs/content/reference/python-api/commands/commands_guide.md
@@ -23,7 +23,7 @@ Here's a basic example of creating a command:
 import angreal
 
 @angreal.command(
-    name="hello", 
+    name="hello",
     about="Say hello to someone",
     when_to_use=["For greeting users", "During initial setup"],
     when_not_to_use=["In automated scripts", "During production deployment"]
@@ -57,7 +57,7 @@ dev = angreal.command_group(name="dev", about="Development commands")
 # Add a command to the group
 @dev()
 @angreal.command(
-    name="build", 
+    name="build",
     about="Build the project",
     when_to_use=["After code changes", "Before testing", "During development"],
     when_not_to_use=["In production environments", "Without code changes"]

--- a/src/builder/command_tree.rs
+++ b/src/builder/command_tree.rs
@@ -66,7 +66,6 @@ pub struct ParameterSchema {
     pub description: Option<String>,
 }
 
-
 impl CommandNode {
     /// Create a new group node
     pub fn new_group(name: String, about: Option<String>) -> Self {
@@ -131,7 +130,11 @@ impl CommandNode {
     }
 
     /// Convert to new schema format
-    pub fn to_project_schema(&self, angreal_root: String, angreal_version: String) -> ProjectSchema {
+    pub fn to_project_schema(
+        &self,
+        angreal_root: String,
+        angreal_version: String,
+    ) -> ProjectSchema {
         let mut commands = Vec::new();
         self.collect_commands(&mut commands, vec![]);
 
@@ -179,7 +182,11 @@ impl CommandNode {
     }
 
     /// Convert to new schema JSON format
-    pub fn to_schema_json(&self, angreal_root: String, angreal_version: String) -> Result<String, serde_json::Error> {
+    pub fn to_schema_json(
+        &self,
+        angreal_root: String,
+        angreal_version: String,
+    ) -> Result<String, serde_json::Error> {
         let schema = self.to_project_schema(angreal_root, angreal_version);
         serde_json::to_string_pretty(&schema)
     }

--- a/src/builder/command_tree.rs
+++ b/src/builder/command_tree.rs
@@ -28,50 +28,44 @@ pub struct SerializableCommand {
     pub long_about: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when_to_use: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when_not_to_use: Option<Vec<String>>,
 }
 
-/// New schema structures for the desired JSON output format
+/// Tree schema for MCP consumption
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectSchema {
-    pub name: String,
+    pub angreal_root: String,
+    pub angreal_version: String,
     pub commands: Vec<CommandSchema>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CommandSchema {
-    pub name: String,
-    pub path: String,
+    pub command: String,
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<String>,
+    pub when_to_use: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when_not_to_use: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub arguments: Vec<ArgumentSchema>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub examples: Vec<ExampleSchema>,
+    pub parameters: Vec<ParameterSchema>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct ArgumentSchema {
+pub struct ParameterSchema {
     pub name: String,
-    pub flag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flag: Option<String>,
     #[serde(rename = "type")]
-    pub arg_type: String,
+    pub param_type: String,
     pub required: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct ExampleSchema {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub args: Vec<String>,
-}
 
 impl CommandNode {
     /// Create a new group node
@@ -94,6 +88,8 @@ impl CommandNode {
                 .group
                 .as_ref()
                 .map(|groups| groups.iter().map(|g| g.name.clone()).collect()),
+            when_to_use: command.when_to_use.clone(),
+            when_not_to_use: command.when_not_to_use.clone(),
         };
 
         CommandNode {
@@ -135,12 +131,13 @@ impl CommandNode {
     }
 
     /// Convert to new schema format
-    pub fn to_project_schema(&self) -> ProjectSchema {
+    pub fn to_project_schema(&self, angreal_root: String, angreal_version: String) -> ProjectSchema {
         let mut commands = Vec::new();
         self.collect_commands(&mut commands, vec![]);
 
         ProjectSchema {
-            name: self.name.clone(),
+            angreal_root,
+            angreal_version,
             commands,
         }
     }
@@ -149,24 +146,18 @@ impl CommandNode {
     fn collect_commands(&self, commands: &mut Vec<CommandSchema>, path_segments: Vec<String>) {
         // If this node has a command, add it to the list
         if let Some(command) = &self.command {
-            let full_path = if path_segments.is_empty() {
+            let full_command = if path_segments.is_empty() {
                 self.name.clone()
             } else {
                 format!("{} {}", path_segments.join(" "), self.name)
             };
 
-            let group = command
-                .group
-                .as_ref()
-                .and_then(|groups| groups.first().cloned());
-
             commands.push(CommandSchema {
-                name: self.name.clone(),
-                path: full_path,
+                command: full_command,
                 description: command.about.clone().unwrap_or_default(),
-                group,
-                arguments: vec![], // Will be populated by caller with actual arguments
-                examples: vec![],  // Could be extended in the future
+                when_to_use: command.when_to_use.clone(),
+                when_not_to_use: command.when_not_to_use.clone(),
+                parameters: vec![], // Will be populated by caller
             });
         }
 
@@ -188,8 +179,8 @@ impl CommandNode {
     }
 
     /// Convert to new schema JSON format
-    pub fn to_schema_json(&self) -> Result<String, serde_json::Error> {
-        let schema = self.to_project_schema();
+    pub fn to_schema_json(&self, angreal_root: String, angreal_version: String) -> Result<String, serde_json::Error> {
+        let schema = self.to_project_schema(angreal_root, angreal_version);
         serde_json::to_string_pretty(&schema)
     }
 }
@@ -225,6 +216,8 @@ mod tests {
                 long_about: None,
                 group: None,
                 func,
+                when_to_use: None,
+                when_not_to_use: None,
             };
 
             let node = CommandNode::new_command(name.clone(), command);
@@ -250,6 +243,8 @@ mod tests {
                 long_about: None,
                 group: None,
                 func: py.None(),
+                when_to_use: None,
+                when_not_to_use: None,
             };
 
             root.add_command(command);
@@ -284,6 +279,8 @@ mod tests {
                 long_about: None,
                 group: Some(vec![group1.clone(), group2.clone()]),
                 func: py.None(),
+                when_to_use: None,
+                when_not_to_use: None,
             };
 
             root.add_command(command);
@@ -320,17 +317,19 @@ mod tests {
                     about: Some("Test group".to_string()),
                 }]),
                 func: py.None(),
+                when_to_use: None,
+                when_not_to_use: None,
             };
 
             root.add_command(command);
 
-            let schema = root.to_project_schema();
+            let schema = root.to_project_schema("/test/root".to_string(), "2.4.2".to_string());
 
-            assert_eq!(schema.name, "angreal");
+            assert_eq!(schema.angreal_root, "/test/root");
+            assert_eq!(schema.angreal_version, "2.4.2");
             assert_eq!(schema.commands.len(), 1);
-            assert_eq!(schema.commands[0].name, "test_cmd");
+            assert_eq!(schema.commands[0].command, "test test_cmd");
             assert_eq!(schema.commands[0].description, "Test command");
-            assert_eq!(schema.commands[0].group, Some("test".to_string()));
         });
     }
 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -89,6 +89,7 @@ fn add_tree_subcommand(app: App<'static>) -> App<'static> {
     app.subcommand(
         Command::new("tree")
             .about("Display the command tree structure")
+            .hide(true)
             .arg(
                 Arg::new("json")
                     .long("json")
@@ -102,6 +103,7 @@ fn add_alias_subcommand(app: App<'static>) -> App<'static> {
     app.subcommand(
         Command::new("alias")
             .about("Manage angreal command aliases")
+            .hide(true)
             .setting(AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 Command::new("create")
@@ -131,6 +133,7 @@ fn add_completion_subcommand(app: App<'static>) -> App<'static> {
     app.subcommand(
         Command::new("completion")
             .about("Manage shell completion")
+            .hide(true)
             .setting(AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 Command::new("install")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ fn get_venv_activation_info(venv_path: &str) -> PyResult<integrations::uv::Activ
 }
 
 /// Handle the tree command
-fn handle_tree_command(sub_matches: &clap::ArgMatches, in_angreal_project: bool) -> PyResult<()> {
+fn handle_tree_command(_sub_matches: &clap::ArgMatches, in_angreal_project: bool) -> PyResult<()> {
     use crate::builder::command_tree::CommandNode;
 
     // Build command tree from registered tasks
@@ -267,19 +267,17 @@ fn handle_tree_command(sub_matches: &clap::ArgMatches, in_angreal_project: bool)
         } else {
             command_parts[0].to_string()
         };
-        
+
         let args = builder::select_args(&command_path);
-        
+
         command_schema.parameters = args
             .into_iter()
             .map(|arg| {
                 // Only set flag field if there's an actual CLI flag (long or short)
                 let flag = if let Some(long) = &arg.long {
                     Some(format!("--{}", long))
-                } else if let Some(short) = arg.short {
-                    Some(format!("-{}", short))
                 } else {
-                    None // Positional argument - no flag
+                    arg.short.map(|short| format!("-{}", short))
                 };
 
                 // Use the actual Python data type, but convert "bool" flag type correctly

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -674,7 +674,6 @@ pub fn extract_prompts(toml_path: PathBuf) -> Result<Map<String, Value>> {
 #[path = "../tests"]
 mod tests {
     use super::*;
-    use pyo3::types::IntoPyDict;
     use pyo3::types::PyDict;
     use std::env;
     use std::fs;


### PR DESCRIPTION
  - Add when_to_use and when_not_to_use guidance to command definitions
  - Update command tree schema to support MCP consumption with project context
  - Improve JSON output format with structured parameter information
  - Bump version to 2.4.2
  - Hide internal commands (tree, alias, completion) from help output
  - Add comprehensive usage guidance to all task commands