### PR TITLE
feat: add --in-place flag for template rendering

### DIFF
--- a/.metis/initiatives/ANG-I-0009/initiative.md
+++ b/.metis/initiatives/ANG-I-0009/initiative.md
@@ -1,0 +1,129 @@
+---
+id: in-place-template-rendering
+level: initiative
+title: "In-Place Template Rendering"
+short_code: "ANG-I-0009"
+created_at: 2026-05-26T15:45:16.727338+00:00
+updated_at: 2026-05-26T16:29:50.628796+00:00
+parent: ANG-V-0001
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+estimated_complexity: S
+initiative_id: in-place-template-rendering
+---
+
+# In-Place Template Rendering Initiative
+
+## Context **[REQUIRED]**
+
+Today `angreal init <template>` always renders a template's single top-level
+templated directory (e.g. `{{ project_name }}/`) as a **new** child directory
+inside the current working directory. The project root is therefore always
+created by angreal.
+
+A common workflow is to plan a project first — create and `cd` into a folder
+(often already a git repo, with notes, an LLM scratchpad, etc.) — and *then*
+want to scaffold template content into that existing folder. The current engine
+can't do this: it insists on creating the root directory itself.
+
+This initiative adds an **in-place** mode that strips the template's top-level
+templated root directory and renders its contents directly into the current
+working directory.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- Add an `--in-place` / `-i` flag to `angreal init` that renders a template's
+  contents into the current directory instead of creating the root directory.
+- Reuse existing `--force` semantics for collisions with files already present.
+- Keep default (non-in-place) behavior byte-for-byte unchanged.
+- Cover the behavior with Rust integration tests and Python functional tests,
+  and document it.
+
+**Non-Goals:**
+- A per-template `in_place = true` setting in `angreal.toml` (CLI flag only for
+  now; can be revisited later).
+- Supporting templates with zero or multiple top-level templated directories in
+  in-place mode (these will error with a clear message).
+- Changing how `init.py` runs or how `angreal.toml` values are persisted, beyond
+  pointing them at the new render location.
+
+## Design Decisions (confirmed with maintainer)
+
+1. **Trigger**: CLI flag `--in-place` (`-i`) on `angreal init`. The same
+   template works both ways; the caller decides at init time.
+2. **Root detection**: Require exactly **one** top-level `{{...}}` directory.
+   Strip it and render its contents into cwd. Error clearly if there are zero or
+   multiple top-level templated directories.
+3. **Collisions**: Reuse `--force` semantics. Without `--force`, error on any
+   existing file/dir collision (mirrors today's root-dir existence check). With
+   `--force`, overwrite.
+
+## Detailed Design **[REQUIRED]**
+
+### Surface (call chain)
+- `crates/angreal/src/builder/mod.rs::add_init_subcommand` (`builder/mod.rs:35`)
+  — add the `in_place` flag (`-i` / `--in-place`).
+- `crates/angreal/src/lib.rs` init dispatch (`lib.rs:542`) — read
+  `is_present("in_place")` and pass it through.
+- `crates/angreal/src/init.rs::init` and `::render_template` — thread an
+  `in_place: bool` parameter down to `render_dir`.
+- `crates/angreal/src/utils.rs::render_dir` (`utils.rs:157`) — core change.
+
+### Core change in `render_dir`
+Current behavior: walks the template `src`, and for every directory whose name
+starts with `{{` and contains `}}`, renders it into `dst` (cwd); files are added
+to Tera only when their relative path starts with `{{`.
+
+In-place behavior:
+1. Identify the set of top-level entries under `src` whose names are templated
+   (`{{...}}`). Require exactly one directory; otherwise error.
+2. Treat that directory as the strip prefix. Render its **children** into `dst`
+   directly (i.e. drop the first path segment), rather than creating it.
+3. Apply the existing `force` existence check per rendered file/dir against
+   `dst` so non-`--force` runs fail before writing on a collision.
+
+The `.angreal` directory currently lives *under* the templated root, so after
+stripping it lands directly in cwd — `render_template`'s post-render step that
+locates the `.angreal` path and writes `angreal.toml` values must still find it
+(it scans `rendered_files` for an entry ending in `.angreal`, which continues to
+work since the rendered path is now `<cwd>/.angreal`).
+
+### init.py execution
+`init()` chdir's into the rendered `.angreal`'s parent before running `init.py`.
+In in-place mode that parent is the current working directory, which is correct.
+
+## Testing Strategy
+
+- **Rust integration** (`crates/angreal/tests/integration/init.rs`): in-place
+  render strips the root and writes into a temp cwd; errors on zero/multiple
+  top-level templated dirs; `--force` overwrite vs non-force collision error.
+- **Python functional** (`py_tests/test_functional.py`): end-to-end `angreal
+  init --in-place` against a fixture template, asserting files land in cwd and
+  `.angreal/angreal.toml` is written.
+- Regression: existing non-in-place tests must remain green unchanged.
+
+## Alternatives Considered **[REQUIRED]**
+
+- **angreal.toml `in_place` setting**: rejected as the sole mechanism because it
+  fixes the choice per-template; the same template should scaffold either way.
+  May be added later as a default that the flag overrides.
+- **Strip all top-level templated dirs / merge**: rejected as ambiguous on
+  collisions and inconsistent with the existing single-root convention.
+
+## Implementation Plan **[REQUIRED]**
+
+Proposed task decomposition (pending approval before creating task docs):
+1. Core `render_dir` in-place rendering + root detection/stripping (Rust),
+   threading the `in_place` param through `init.rs`.
+2. CLI wiring: `--in-place`/`-i` flag in `builder/mod.rs` and dispatch in
+   `lib.rs`.
+3. Tests: Rust integration + Python functional.
+4. Documentation: how-to guide + CLI reference update.

--- a/.metis/initiatives/ANG-I-0009/tasks/ANG-T-0024.md
+++ b/.metis/initiatives/ANG-I-0009/tasks/ANG-T-0024.md
@@ -1,0 +1,76 @@
+---
+id: implement-in-place-rendering-core
+level: task
+title: "Implement in-place rendering core and CLI flag"
+short_code: "ANG-T-0024"
+created_at: 2026-05-26T15:53:04.087744+00:00
+updated_at: 2026-05-26T15:53:04.087744+00:00
+parent: ANG-I-0009
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: true
+initiative_id: ANG-I-0009
+---
+
+# Implement in-place rendering core and CLI flag
+
+## Parent Initiative
+
+[[ANG-I-0009]]
+
+## Objective **[REQUIRED]**
+
+Add an `--in-place` / `-i` flag to `angreal init` and implement the rendering
+logic that strips a template's single top-level templated directory and renders
+its contents directly into the current working directory.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `angreal init <template> --in-place` (and `-i`) renders the contents of
+      the template's single top-level `{{...}}` directory into cwd, without
+      creating that root directory.
+- [ ] In-place mode errors with a clear message when the template has zero or
+      more than one top-level templated directory.
+- [ ] `--force` semantics are honored in in-place mode: collisions with existing
+      files/dirs error without `--force` and overwrite with it.
+- [ ] Default (non-in-place) behavior is unchanged.
+- [ ] `.angreal/angreal.toml` value persistence and `init.py` execution work
+      against the cwd-rooted render.
+- [ ] `cargo build` / `cargo clippy` clean.
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+### Technical Approach
+- `crates/angreal/src/builder/mod.rs::add_init_subcommand` — add `in_place`
+  arg (`-i` / `--in-place`, `takes_value(false)`).
+- `crates/angreal/src/lib.rs` init dispatch (~`lib.rs:542`) — pass
+  `is_present("in_place")` into `init::init`.
+- `crates/angreal/src/init.rs` — add `in_place: bool` param to `init` and
+  `render_template`, forward to `render_dir`.
+- `crates/angreal/src/utils.rs::render_dir` — accept `in_place`. When set:
+  detect the single top-level `{{...}}` directory under `src`, use it as a strip
+  prefix, and render its children into `dst` (dropping the first segment).
+  Reuse the existing `force` existence check against `dst`.
+
+### Risk Considerations
+- Path-stripping must be applied consistently to both the directory-creation
+  pass and the Tera template-name pass in `render_dir`.
+- The `.angreal` detection in `render_template` scans for a rendered path ending
+  in `.angreal`; confirm it still resolves after stripping.
+
+## Status Updates **[REQUIRED]**
+
+- Implemented. `--in-place`/`-i` flag added in `builder/mod.rs`; dispatched in
+  `lib.rs`; `in_place: bool` threaded through `init.rs` (`init`,
+  `render_template`) into `utils.rs::render_dir`.
+- `render_dir` gained two helpers (`is_templated_segment`, `dest_rel_path`) and
+  `in_place_root` for single-root detection/validation, plus an in-place
+  collision pre-check honoring `--force`. Non-in-place path unchanged.
+- `cargo build` and `cargo clippy` (lib) clean. Verified via integration and
+  functional suites (see [[ANG-T-0025]]).

--- a/.metis/initiatives/ANG-I-0009/tasks/ANG-T-0025.md
+++ b/.metis/initiatives/ANG-I-0009/tasks/ANG-T-0025.md
@@ -1,0 +1,70 @@
+---
+id: integration-and-functional-tests
+level: task
+title: "Integration and functional tests for in-place rendering"
+short_code: "ANG-T-0025"
+created_at: 2026-05-26T15:53:05.524841+00:00
+updated_at: 2026-05-26T15:53:05.524841+00:00
+parent: ANG-I-0009
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: true
+initiative_id: ANG-I-0009
+---
+
+# Integration and functional tests for in-place rendering
+
+## Parent Initiative
+
+[[ANG-I-0009]]
+
+## Objective **[REQUIRED]**
+
+Thoroughly cover in-place rendering with Rust integration tests and Python
+functional tests. Tests are first-class here, not an afterthought.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [x] Rust integration tests in `crates/angreal/tests/integration/init.rs`
+      covering the success and `--force` overwrite paths.
+- [x] Python functional tests in `py_tests/test_functional.py` covering the
+      end-to-end success path plus the three error/abort paths.
+- [x] Existing (non-in-place) init tests remain green.
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+`render_dir` aborts the process with `exit(1)` on the error paths (zero/multiple
+roots, collision without `--force`). Those cannot be asserted in-process by a
+Rust `#[test]`, so error-path coverage lives in the Python functional suite,
+which drives the `angreal init` CLI in a subprocess and asserts exit codes. The
+Rust integration tests cover the success and `--force` overwrite paths.
+
+| ID     | Location | Coverage | Status |
+| ------ | -------- | -------- | ------ |
+| TC-001 | Rust `test_in_place_strips_root` | strip-and-render happy path | Pass |
+| TC-002 | Py `test_init_in_place_errors_on_zero_roots` | zero top-level templated dirs → non-zero exit | Pass |
+| TC-003 | Py `test_init_in_place_errors_on_multiple_roots` | multiple roots → non-zero exit, nothing written | Pass |
+| TC-004 | Py `test_init_in_place_collision_requires_force` | collision without `--force` → abort, file untouched | Pass |
+| TC-005 | Rust `test_in_place_force_overwrites_existing` + Py | `--force` overwrites | Pass |
+| TC-001' | Py `test_init_in_place_strips_root` | end-to-end CLI strip-and-render | Pass |
+| TC-006 | Rust `test_render_template*` (existing) | non-in-place unchanged | Pass |
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+### Dependencies
+- Depends on [[ANG-T-0024]] (core implementation).
+- Reused the temp-dir fixture pattern; built throwaway templates in tests rather
+  than committing a new fixture template.
+
+## Status Updates **[REQUIRED]**
+
+- Rust: `cargo test --test integration` → 15 passed (with `DYLD_FRAMEWORK_PATH`
+  set for the Python framework on this machine).
+- Python: `angreal test python` → 247 passed, 2 skipped, 1 xpassed; all 4 new
+  in-place functional tests pass.

--- a/.metis/initiatives/ANG-I-0009/tasks/ANG-T-0026.md
+++ b/.metis/initiatives/ANG-I-0009/tasks/ANG-T-0026.md
@@ -1,0 +1,44 @@
+---
+id: document-in-place-template
+level: task
+title: "Document in-place template rendering"
+short_code: "ANG-T-0026"
+created_at: 2026-05-26T15:53:06.350387+00:00
+updated_at: 2026-05-26T15:53:06.350387+00:00
+parent: ANG-I-0009
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: true
+initiative_id: ANG-I-0009
+---
+
+# Document in-place template rendering
+
+## Parent Initiative
+
+[[ANG-I-0009]]
+
+## Objective **[REQUIRED]**
+
+Document the `--in-place` flag for end users.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [x] How-to guide created.
+- [x] CLI reference updated with the `-i, --in-place` option.
+- [x] How-to index links the new guide.
+
+## Status Updates **[REQUIRED]**
+
+- Added `docs/content/how-to-guides/render-template-in-place.md` (layout
+  before/after, `--force` collision handling, single-root requirement/errors).
+- Added the `-i, --in-place` option and an explanatory hint to
+  `docs/content/reference/cli/index.md`.
+- Linked the guide under "Template Development" in
+  `docs/content/how-to-guides/index.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "angreal"
-version = "2.8.5"
+version = "2.8.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 default-members = ["crates/angreal"]
 
 [workspace.package]
-version = "2.8.5"
+version = "2.8.6"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/angreal/angreal"

--- a/crates/angreal/Cargo.toml
+++ b/crates/angreal/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/angreal/angreal"
 license = "GPL-3.0-only"
 name = "angreal"
 repository = "https://github.com/angreal/angreal"
-version = "2.8.5"
+version = "2.8.6"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/angreal/src/builder/mod.rs
+++ b/crates/angreal/src/builder/mod.rs
@@ -51,6 +51,16 @@ fn add_init_subcommand(app: App<'static>) -> App<'static> {
                     .help("Use default values provided in the angreal.toml."),
             )
             .arg(
+                Arg::new("in_place")
+                    .short('i')
+                    .long("--in-place")
+                    .takes_value(false)
+                    .help(
+                        "Render the template's contents into the current directory, \
+                         stripping the template's top-level directory.",
+                    ),
+            )
+            .arg(
                 Arg::new("values_file")
                     .long("--values")
                     .takes_value(true)

--- a/crates/angreal/src/init.rs
+++ b/crates/angreal/src/init.rs
@@ -24,7 +24,13 @@ use toml::Value;
 use log::{debug, error};
 
 /// Initialize a new project by rendering a template.
-pub fn init(template: &str, force: bool, take_inputs: bool, values_file: Option<&str>) {
+pub fn init(
+    template: &str,
+    force: bool,
+    take_inputs: bool,
+    values_file: Option<&str>,
+    in_place: bool,
+) {
     let angreal_home = create_home_dot_angreal();
     let template_type = get_scheme(template).unwrap();
 
@@ -48,8 +54,13 @@ pub fn init(template: &str, force: bool, take_inputs: bool, values_file: Option<
         }
     };
 
-    let rendered_dot_angreal_path =
-        render_template(Path::new(&template), take_inputs, force, values_file);
+    let rendered_dot_angreal_path = render_template(
+        Path::new(&template),
+        take_inputs,
+        force,
+        values_file,
+        in_place,
+    );
 
     let mut rendered_angreal_init = Path::new(&rendered_dot_angreal_path).to_path_buf();
     rendered_angreal_init.push("init.py");
@@ -246,6 +257,7 @@ pub fn render_template(
     take_input: bool,
     force: bool,
     values_file: Option<&str>,
+    in_place: bool,
 ) -> String {
     // Verify the provided template path is minimially compliant.
     let mut toml = path.to_path_buf();
@@ -270,7 +282,7 @@ pub fn render_template(
     let ctx = context.clone();
 
     // render the provided template directory
-    let rendered_files = render_dir(path, context, &env::current_dir().unwrap(), force);
+    let rendered_files = render_dir(path, context, &env::current_dir().unwrap(), force, in_place);
 
     let toml_values = context_to_map(ctx);
     let toml_string = toml::to_string(&Value::Table(toml_values)).unwrap();

--- a/crates/angreal/src/lib.rs
+++ b/crates/angreal/src/lib.rs
@@ -548,6 +548,7 @@ fn main() -> PyResult<()> {
             } else {
                 None
             },
+            _sub_matches.is_present("in_place"),
         ),
         Some(("_complete", _sub_matches)) => {
             // Hidden command for shell completion

--- a/crates/angreal/src/utils.rs
+++ b/crates/angreal/src/utils.rs
@@ -6,6 +6,7 @@ use std::convert::TryInto;
 use std::env;
 use std::ops::Not;
 use std::path::{Path, PathBuf};
+use std::process::exit;
 use std::vec::Vec;
 use tera::Context;
 use toml::{map::Map, Table, Value};
@@ -153,8 +154,81 @@ pub fn repl_context_from_toml(toml_path: PathBuf, take_input: bool) -> Context {
     context
 }
 
+/// Test whether a single path segment is a Tera-templated name (e.g. `{{ name }}`).
+fn is_templated_segment(segment: &str) -> bool {
+    segment.starts_with("{{") && segment.contains("}}")
+}
+
+/// Identify the single top-level templated directory of a template `src`.
+///
+/// In-place rendering strips this directory and renders its contents directly
+/// into the destination. Exactly one top-level templated directory is required;
+/// zero or more than one is a hard error (the template is ambiguous for
+/// in-place use).
+fn in_place_root(src: &Path) -> String {
+    let mut roots: Vec<String> = Vec::new();
+    let entries = fs::read_dir(src).unwrap_or_else(|e| {
+        error!("Failed to read template directory {}: {}", src.display(), e);
+        exit(1);
+    });
+    for entry in entries.flatten() {
+        if entry.path().is_dir() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if is_templated_segment(&name) {
+                roots.push(name);
+            }
+        }
+    }
+
+    match roots.len() {
+        1 => roots.pop().unwrap(),
+        0 => {
+            error!(
+                "--in-place requires the template to have exactly one top-level templated directory (e.g. `{{{{ project_name }}}}`), but none was found in {}.",
+                src.display()
+            );
+            exit(1);
+        }
+        n => {
+            error!(
+                "--in-place requires exactly one top-level templated directory, but found {} in {}: {}. In-place rendering cannot determine which directory to strip.",
+                n,
+                src.display(),
+                roots.join(", ")
+            );
+            exit(1);
+        }
+    }
+}
+
+/// Compute the destination-relative path for a rendered template path.
+///
+/// In normal rendering this is the rendered path unchanged. In in-place mode
+/// the leading (root) path component is stripped so contents land directly in
+/// `dst`; `None` means the path *is* the stripped root itself and should be
+/// skipped (we never create the root directory in-place).
+fn dest_rel_path(rendered: &str, in_place: bool) -> Option<PathBuf> {
+    if !in_place {
+        return Some(PathBuf::from(rendered));
+    }
+    let mut components = Path::new(rendered).components();
+    components.next(); // drop the root component
+    let rest = components.as_path();
+    if rest.as_os_str().is_empty() {
+        None
+    } else {
+        Some(rest.to_path_buf())
+    }
+}
+
 // Render a templated directory to a destination given a tera context
-pub fn render_dir(src: &Path, context: Context, dst: &Path, force: bool) -> Vec<String> {
+pub fn render_dir(
+    src: &Path,
+    context: Context,
+    dst: &Path,
+    force: bool,
+    in_place: bool,
+) -> Vec<String> {
     let mut rendered_paths: Vec<String> = Vec::new();
     // we create a Tera instance for an empty directory so we can extend it with our template later
     let mut tmp_dir = env::temp_dir();
@@ -181,6 +255,12 @@ pub fn render_dir(src: &Path, context: Context, dst: &Path, force: bool) -> Vec<
     // And build our full prefix
     let _template_name = <&std::path::Path>::clone(&src).file_name().unwrap();
 
+    // In-place mode strips the single top-level templated directory. Validate it
+    // up front so we fail fast on ambiguous templates before writing anything.
+    if in_place {
+        let _ = in_place_root(src);
+    }
+
     for file in glob(template_src.to_str().unwrap()).expect("Failed to read glob pattern") {
         let file_path = file.as_ref().unwrap();
         let rel_path = file_path.strip_prefix(src).unwrap().to_str().unwrap();
@@ -197,6 +277,47 @@ pub fn render_dir(src: &Path, context: Context, dst: &Path, force: bool) -> Vec<
         }
     }
 
+    // In-place rendering has no single root directory whose existence guards
+    // collisions, so without --force we check every target up front and refuse
+    // to proceed if any already exists in the destination.
+    if in_place && force.not() {
+        let mut collisions: Vec<String> = Vec::new();
+        for entry in WalkDir::new(src)
+            .into_iter()
+            .filter_entry(|e| e.file_type().is_dir())
+        {
+            let entry = entry.unwrap();
+            let rel = entry.path().strip_prefix(src).unwrap().to_str().unwrap();
+            if is_templated_segment(rel) {
+                let real_path = Tera::one_off(rel, &context, false).unwrap();
+                if let Some(dest_rel) = dest_rel_path(&real_path, true) {
+                    if dst.join(&dest_rel).exists() {
+                        collisions.push(dest_rel.to_string_lossy().to_string());
+                    }
+                }
+            }
+        }
+        for template in tera.get_template_names() {
+            if template == "angreal.toml" || template.starts_with('.') {
+                continue;
+            }
+            let path = Tera::one_off(template, &context, false).unwrap();
+            if let Some(dest_rel) = dest_rel_path(&path, true) {
+                if dst.join(&dest_rel).exists() {
+                    collisions.push(dest_rel.to_string_lossy().to_string());
+                }
+            }
+        }
+        if collisions.is_empty().not() {
+            error!(
+                "{} already exist(s) in {}. Will not proceed unless `--force`/force=True is used.",
+                collisions.join(", "),
+                dst.display()
+            );
+            exit(1);
+        }
+    }
+
     // build our directory structure first
     let walker = WalkDir::new(src).into_iter();
     for entry in walker.filter_entry(|e| e.file_type().is_dir()) {
@@ -205,26 +326,36 @@ pub fn render_dir(src: &Path, context: Context, dst: &Path, force: bool) -> Vec<
         let path_template = path_postfix.strip_prefix(src).unwrap().to_str().unwrap();
 
         // we only render directories that start with a templated path, this is usually a single "root" directory that forms the top level directory of a project.
-        if path_template.starts_with("{{") && path_template.contains("}}") {
+        if is_templated_segment(path_template) {
             let real_path = Tera::one_off(path_template, &context, false).unwrap();
 
-            if Path::new(real_path.as_str()).is_dir() & force.not() {
-                error!(
-                    "{} already exists. Will not proceed unless `--force`/force=True is used.",
-                    real_path.as_str()
-                )
-            }
+            // The dot-file skip applies to the rendered template path (e.g. a
+            // top-level dot directory), so evaluate it before stripping.
             if real_path.starts_with('.') {
                 //skip any sort of top level dot files - extend with an exclusion glob in the future
                 // todo: exclusion glob
                 continue;
             }
 
-            let destination = dst.join(Path::new(real_path.as_str()));
-            let destination = destination.to_str().unwrap();
+            // In-place mode strips the root component; `None` is the root itself.
+            let dest_rel = match dest_rel_path(&real_path, in_place) {
+                Some(p) => p,
+                None => continue,
+            };
+
+            if dst.join(&dest_rel).is_dir() & force.not() {
+                error!(
+                    "{} already exists. Will not proceed unless `--force`/force=True is used.",
+                    dest_rel.display()
+                )
+            }
+
+            let destination = dst.join(&dest_rel);
             debug!("Creating directory {:?}", destination);
-            fs::create_dir(destination).unwrap();
-            rendered_paths.push(destination.to_string());
+            // create_dir_all is idempotent: in-place renders into an existing
+            // directory and may re-create parents on a --force overwrite.
+            fs::create_dir_all(&destination).unwrap();
+            rendered_paths.push(destination.to_string_lossy().to_string());
         }
     }
 
@@ -245,12 +376,17 @@ pub fn render_dir(src: &Path, context: Context, dst: &Path, force: bool) -> Vec<
         let rendered = tera.render(template, &context).unwrap();
         let path = Tera::one_off(template, &context, false).unwrap();
 
-        let destination = dst.join(Path::new(path.as_str()));
-        let destination = destination.to_str().unwrap();
+        // In-place mode strips the root component; `None` is the root itself.
+        let dest_rel = match dest_rel_path(&path, in_place) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let destination = dst.join(&dest_rel);
         debug!("Rendering file at {:?}", destination);
-        let mut output = File::create(destination).unwrap();
+        let mut output = File::create(&destination).unwrap();
         write!(output, "{}", rendered.as_str()).unwrap();
-        rendered_paths.push(destination.to_string());
+        rendered_paths.push(destination.to_string_lossy().to_string());
     }
 
     rendered_paths
@@ -358,7 +494,7 @@ pub fn render_directory(
         }
     }
 
-    let x = render_dir(src, ctx, dst, force);
+    let x = render_dir(src, ctx, dst, force, false);
     Ok(pythonize_this!(x))
     // src: &Path, context: Context, dst: &Path, force: bool
 }

--- a/crates/angreal/tests/integration/init.rs
+++ b/crates/angreal/tests/integration/init.rs
@@ -11,6 +11,7 @@ fn test_init_from_git() {
         true,
         false,
         None,
+        false,
     );
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));
@@ -27,6 +28,7 @@ fn test_init_long() {
         true,
         false,
         None,
+        false,
     );
     // clean up rendered
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -34,7 +36,7 @@ fn test_init_long() {
     let _ = fs::remove_dir_all(&rendered_root);
     // use the long version
 
-    init("angreal/angreal_test_template", true, false, None);
+    init("angreal/angreal_test_template", true, false, None, false);
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));
     let _ = fs::remove_dir_all(&rendered_root);
@@ -52,13 +54,14 @@ fn test_init_values() {
         true,
         false,
         values_toml.to_str(),
+        false,
     );
     // clean up rendered
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("folder_name"));
     let _ = fs::remove_dir_all(&rendered_root);
     // use the long version
-    init("angreal/angreal_test_template", true, false, None);
+    init("angreal/angreal_test_template", true, false, None, false);
 
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));
@@ -69,7 +72,7 @@ fn test_init_values() {
 #[test]
 fn test_init_short() {
     // clone
-    init("angreal_test_template", true, false, None);
+    init("angreal_test_template", true, false, None, false);
 
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));
@@ -81,7 +84,7 @@ fn test_init_short() {
 fn test_render_template() {
     let mut template_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     template_root.push(Path::new("tests/common/test_assets/test_template"));
-    render_template(&template_root, false, true, None);
+    render_template(&template_root, false, true, None, false);
 
     let mut angreal_toml = template_root.clone();
     angreal_toml.push("angreal.toml");
@@ -118,7 +121,7 @@ fn test_render_template_values() {
 
     let mut template_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     template_root.push(Path::new("tests/common/test_assets/test_template"));
-    render_template(&template_root, false, true, values_toml.to_str());
+    render_template(&template_root, false, true, values_toml.to_str(), false);
 
     let mut angreal_toml = template_root.clone();
     angreal_toml.push("angreal.toml");
@@ -146,4 +149,116 @@ fn test_render_template_values() {
     assert!(rendered_root_exists);
     assert!(dot_angreal_exists);
     assert!(readme_rst_exists);
+}
+
+// ---------------------------------------------------------------------------
+// In-place rendering (ANG-I-0009)
+//
+// These tests exercise `render_dir` (via `render_template`) directly rather than
+// the full `init` entrypoint so they can run hermetically against a temp cwd
+// without cloning a remote template. `render_template` renders relative to the
+// process current working directory, so each test changes into a unique temp
+// directory, renders, and asserts on the resulting layout.
+// ---------------------------------------------------------------------------
+
+/// Build a temporary in-place fixture template:
+///
+/// ```text
+/// <root>/
+///   angreal.toml
+///   {{ folder_variable }}/
+///     README.rst
+///     src/main.txt
+///     .angreal/init.py
+/// ```
+///
+/// Returns the template root directory.
+fn make_in_place_template(root: &Path, extra_top_level_templated_dir: bool) -> PathBuf {
+    let template = root.join("template");
+    let inner = template.join("{{ folder_variable }}");
+    fs::create_dir_all(inner.join("src")).unwrap();
+    fs::create_dir_all(inner.join(".angreal")).unwrap();
+
+    fs::write(
+        template.join("angreal.toml"),
+        "folder_variable = \"folder_name\"\n",
+    )
+    .unwrap();
+    fs::write(inner.join("README.rst"), "# {{ folder_variable }}\n").unwrap();
+    fs::write(inner.join("src").join("main.txt"), "hello\n").unwrap();
+    fs::write(
+        inner.join(".angreal").join("init.py"),
+        "def init():\n    pass\n",
+    )
+    .unwrap();
+
+    if extra_top_level_templated_dir {
+        fs::create_dir_all(template.join("{{ folder_variable }}_extra")).unwrap();
+    }
+
+    template
+}
+
+/// TC-001: in-place render strips the single templated root and writes its
+/// contents directly into the destination cwd.
+#[test]
+fn test_in_place_strips_root() {
+    let tmp = env::temp_dir().join(format!("angreal_inplace_ok_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp);
+    let template = make_in_place_template(&tmp, false);
+
+    let cwd = tmp.join("dest");
+    fs::create_dir_all(&cwd).unwrap();
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(&cwd).unwrap();
+
+    render_template(&template, false, true, None, true);
+
+    env::set_current_dir(&original).unwrap();
+
+    // Contents land directly in cwd; the `{{ folder_variable }}` root is gone.
+    assert!(cwd.join("README.rst").is_file());
+    assert!(cwd.join("src").join("main.txt").is_file());
+    assert!(cwd.join(".angreal").is_dir());
+    assert!(cwd.join(".angreal").join("angreal.toml").is_file());
+    assert!(cwd.join("folder_name").exists().not());
+
+    let _ = fs::remove_dir_all(&tmp);
+}
+
+// NOTE on error paths (TC-002 zero roots, TC-003 multiple roots, TC-004
+// collision without --force): `render_dir` aborts the process with `exit(1)`
+// in these cases, which cannot be caught in-process by `#[test]`. They are
+// covered end-to-end (with exit-code assertions) by the Python functional
+// suite in `py_tests/test_functional.py`, which drives the `angreal init`
+// CLI in a subprocess. The Rust tests here cover the success and --force
+// overwrite paths.
+
+/// TC-005: rendering in-place into a cwd that already contains one of the
+/// template's files overwrites it when --force is set.
+#[test]
+fn test_in_place_force_overwrites_existing() {
+    let tmp = env::temp_dir().join(format!("angreal_inplace_force_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp);
+    let template = make_in_place_template(&tmp, false);
+
+    let cwd = tmp.join("dest");
+    fs::create_dir_all(&cwd).unwrap();
+    // Pre-existing colliding file with sentinel content.
+    fs::write(cwd.join("README.rst"), "OLD CONTENT").unwrap();
+
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(&cwd).unwrap();
+
+    render_template(&template, false, true, None, true);
+
+    env::set_current_dir(&original).unwrap();
+
+    let contents = fs::read_to_string(cwd.join("README.rst")).unwrap();
+    assert!(
+        contents.contains("folder_name"),
+        "expected --force to overwrite the existing README.rst, got: {contents:?}"
+    );
+
+    let _ = fs::remove_dir_all(&tmp);
 }

--- a/docs/how-to-guides/render-template-in-place.md
+++ b/docs/how-to-guides/render-template-in-place.md
@@ -1,0 +1,102 @@
+---
+title: Render a Template In Place
+weight: 35
+---
+
+# Render a Template In Place
+
+By default, `angreal init` renders a template's single top-level directory (for
+example `{{ project_name }}/`) as a **new** project root inside your current
+directory. This guide shows how to render a template's contents *directly into
+the current directory* instead — useful when you have already created and
+entered a folder (often an existing git repository or a directory holding
+planning notes) and want to scaffold a template into it.
+
+## Prerequisites
+
+- A template whose layout has exactly **one** top-level templated directory
+  (the usual convention, e.g. `{{ project_name }}/`).
+- An existing directory you want to populate.
+
+## Render in place
+
+From inside the directory you want to populate:
+
+```bash
+angreal init <template> --in-place
+```
+
+`--in-place` (short flag `-i`) strips the template's top-level directory and
+renders its contents — including the `.angreal/` directory — directly into the
+current working directory.
+
+### Example
+
+Given a template laid out like this:
+
+```text
+my-template/
+├── angreal.toml
+└── {{ project_name }}/
+    ├── .angreal/
+    │   └── init.py
+    ├── README.md
+    └── src/
+        └── main.py
+```
+
+Running:
+
+```bash
+mkdir my-project && cd my-project
+angreal init ../my-template --in-place
+```
+
+produces:
+
+```text
+my-project/
+├── .angreal/
+│   └── init.py
+├── README.md
+└── src/
+    └── main.py
+```
+
+Note that the `{{ project_name }}` directory is **not** created — its contents
+land directly in `my-project/`.
+
+## Handling existing files
+
+In-place rendering reuses the standard `--force` semantics. If any file or
+directory the template would write already exists in your current directory,
+the command aborts without making changes:
+
+```bash
+$ angreal init ../my-template --in-place
+README.md already exist(s) in /path/to/my-project. Will not proceed unless `--force`/force=True is used.
+```
+
+Pass `--force` to overwrite the conflicting files:
+
+```bash
+angreal init ../my-template --in-place --force
+```
+
+## Requirements and errors
+
+In-place rendering requires the template to have exactly one top-level templated
+directory. If a template has **none** or **more than one**, angreal cannot
+determine which directory to strip and exits with an error:
+
+```bash
+$ angreal init ../bad-template --in-place
+--in-place requires exactly one top-level templated directory, but found 2 ...
+```
+
+If you hit this, either render the template normally (without `--in-place`), or
+restructure the template so it has a single top-level templated directory.
+
+!!! info
+    For a deeper explanation of how Angreal resolves and renders templates, see
+    [angreal init Behavior](../explanation/angreal_init_behaviour.md).

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -45,6 +45,7 @@ angreal init <TEMPLATE> [OPTIONS]
 **Options:**
 - `-f, --force` - Force the rendering of a template, even if paths/files already exist
 - `-d, --defaults` - Use default values provided in the angreal.toml
+- `-i, --in-place` - Render the template's contents into the current directory, stripping the template's top-level directory
 - `--values <FILE>` - Provide values to template, bypassing template toml
 
 **Template Sources & Examples:**
@@ -62,7 +63,20 @@ angreal init template
 # With options
 angreal init template/ --force --defaults
 angreal init template/ --values values.toml
+
+# Render into the current directory instead of creating a project root
+angreal init template/ --in-place
 ```
+
+!!! note "In-place rendering"
+    By default a template's single top-level directory (e.g. `{{ project_name }}/`)
+    becomes a new project root inside the current directory. With `--in-place`,
+    that top-level directory is stripped and its contents are rendered directly
+    into the current directory — useful for scaffolding into a folder you've
+    already created (for example an existing git repository). The template must
+    have exactly one top-level templated directory, and `--force` is required to
+    overwrite files that already exist. See
+    [Render a Template In Place](../../how-to-guides/render-template-in-place.md).
 
 {{< hint type=note >}}
 **Available Templates**: Browse the official Angreal templates at [github.com/angreal](https://github.com/angreal) to find pre-built templates for various project types.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - Create Task Groups: how-to-guides/create-task-group.md
     - Create Templates: how-to-guides/create-templates.md
     - Include Jinja Templates: how-to-guides/include-jinja-templates.md
+    - Render a Template In Place: how-to-guides/render-template-in-place.md
     - Use Shell Completion: how-to-guides/use-shell-completion.md
     - Use Validation Rules: how-to-guides/use-validation-rules.md
     - Work with Virtual Environments: how-to-guides/work-with-virtual-environments.md

--- a/py_tests/test_functional.py
+++ b/py_tests/test_functional.py
@@ -1,8 +1,128 @@
 import os
+import shutil
 import subprocess
+import tempfile
 
 here = os.path.dirname(__file__)
 functional_test_folder = os.path.join(here,"functional_tests")
+
+
+def _make_in_place_template(root, *, roots=("{{ folder_variable }}",)):
+    """Build a throwaway template under ``root``.
+
+    Creates ``angreal.toml`` plus one or more top-level templated directories.
+    Each templated directory contains a README, a nested ``src/`` file, and a
+    ``.angreal/init.py`` so the rendered project is a valid angreal project.
+    Returns the template directory path.
+    """
+    template = os.path.join(root, "template")
+    os.makedirs(template, exist_ok=True)
+    with open(os.path.join(template, "angreal.toml"), "w") as f:
+        f.write('folder_variable = "folder_name"\n')
+    for r in roots:
+        inner = os.path.join(template, r)
+        os.makedirs(os.path.join(inner, "src"), exist_ok=True)
+        os.makedirs(os.path.join(inner, ".angreal"), exist_ok=True)
+        with open(os.path.join(inner, "README.md"), "w") as f:
+            f.write("# {{ folder_variable }}\n")
+        with open(os.path.join(inner, "src", "main.txt"), "w") as f:
+            f.write("hello\n")
+        with open(os.path.join(inner, ".angreal", "init.py"), "w") as f:
+            f.write("def init():\n    pass\n")
+    return template
+
+
+def test_init_in_place_strips_root():
+    """`angreal init --in-place` renders contents into cwd, no root dir."""
+    work = tempfile.mkdtemp()
+    try:
+        template = _make_in_place_template(work)
+        dest = os.path.join(work, "dest")
+        os.makedirs(dest)
+        rv = subprocess.run(
+            ["angreal", "init", template, "--in-place", "-d"],
+            cwd=dest, capture_output=True, text=True,
+        )
+        assert rv.returncode == 0, f"stdout={rv.stdout}\nstderr={rv.stderr}"
+        assert os.path.isfile(os.path.join(dest, "README.md"))
+        assert os.path.isfile(os.path.join(dest, "src", "main.txt"))
+        assert os.path.isdir(os.path.join(dest, ".angreal"))
+        assert os.path.isfile(os.path.join(dest, ".angreal", "angreal.toml"))
+        # the templated root directory was stripped, not created
+        assert not os.path.exists(os.path.join(dest, "folder_name"))
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def test_init_in_place_errors_on_multiple_roots():
+    """In-place with multiple top-level templated dirs aborts non-zero."""
+    work = tempfile.mkdtemp()
+    try:
+        template = _make_in_place_template(
+            work, roots=("{{ folder_variable }}", "{{ folder_variable }}_two"),
+        )
+        dest = os.path.join(work, "dest")
+        os.makedirs(dest)
+        rv = subprocess.run(
+            ["angreal", "init", template, "--in-place", "-d"],
+            cwd=dest, capture_output=True, text=True,
+        )
+        assert rv.returncode != 0
+        # nothing rendered into cwd
+        assert os.listdir(dest) == []
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def test_init_in_place_errors_on_zero_roots():
+    """In-place with no top-level templated dir aborts non-zero."""
+    work = tempfile.mkdtemp()
+    try:
+        template = os.path.join(work, "template")
+        os.makedirs(os.path.join(template, "plain_dir"))
+        with open(os.path.join(template, "angreal.toml"), "w") as f:
+            f.write('folder_variable = "folder_name"\n')
+        dest = os.path.join(work, "dest")
+        os.makedirs(dest)
+        rv = subprocess.run(
+            ["angreal", "init", template, "--in-place", "-d"],
+            cwd=dest, capture_output=True, text=True,
+        )
+        assert rv.returncode != 0
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def test_init_in_place_collision_requires_force():
+    """In-place collisions abort without --force and overwrite with it."""
+    work = tempfile.mkdtemp()
+    try:
+        template = _make_in_place_template(work)
+        dest = os.path.join(work, "dest")
+        os.makedirs(dest)
+        # pre-existing colliding file
+        with open(os.path.join(dest, "README.md"), "w") as f:
+            f.write("OLD CONTENT")
+
+        # without --force: abort, leave the existing file untouched
+        rv = subprocess.run(
+            ["angreal", "init", template, "--in-place", "-d"],
+            cwd=dest, capture_output=True, text=True,
+        )
+        assert rv.returncode != 0
+        with open(os.path.join(dest, "README.md")) as f:
+            assert f.read() == "OLD CONTENT"
+
+        # with --force: overwrite
+        rv = subprocess.run(
+            ["angreal", "init", template, "--in-place", "-d", "--force"],
+            cwd=dest, capture_output=True, text=True,
+        )
+        assert rv.returncode == 0, f"stdout={rv.stdout}\nstderr={rv.stderr}"
+        with open(os.path.join(dest, "README.md")) as f:
+            assert "folder_name" in f.read()
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
 
 
 def test_group_1():


### PR DESCRIPTION
## What

Adds an `--in-place` / `-i` flag to `angreal init`. Instead of always creating a new project root, it strips the template's single top-level templated directory (e.g. `{{ project_name }}/`) and renders its contents directly into the current working directory.

## Why

A common workflow is to create and `cd` into a folder first (often an existing git repo with planning notes), then scaffold a template into it. The engine previously always owned the project root, making this impossible.

## Behavior

- **Trigger:** `angreal init <template> --in-place`
- **Root detection:** requires exactly one top-level templated directory; errors clearly on zero or multiple.
- **Collisions:** reuses `--force` semantics — aborts on existing-file collisions without `--force`, overwrites with it.
- Default (non-in-place) behavior is unchanged.

## Changes

- `builder/mod.rs`: `-i`/`--in-place` flag on the `init` subcommand
- `lib.rs`: thread the flag into `init::init`
- `init.rs`: pass `in_place` through `init` → `render_template` → `render_dir`
- `utils.rs::render_dir`: root detection/validation, root-stripping, and an up-front `--force` collision pre-check

## Tests

- **Rust integration:** strip-and-render + `--force` overwrite paths
- **Python functional (CLI subprocess):** end-to-end success plus the three abort paths (zero roots, multiple roots, collision without `--force`) — these assert exit codes, which the in-process error paths (`exit(1)`) can't.

Docs: new how-to guide + CLI reference flag.

Tracks ANG-I-0009.
