### PR TITLE
chore: freshen angreal plugin for 2.8.6 + fix release twine bug

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "angreal",
       "source": "./plugin",
       "description": "Task automation skills for angreal projects. Focused skills for running tasks, authoring tasks, arguments, ToolDescriptions, project setup, creating templates, and development patterns.",
-      "version": "2.9.0"
+      "version": "2.8.6"
     }
   ]
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,7 +172,6 @@ jobs:
         run: |
           pip install --upgrade twine
           twine upload --skip-existing dist/*
-          twine upload --skip-existing *
 
 
   test-pypi:

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "angreal",
-  "version": "2.8.4",
+  "version": "2.8.6",
   "description": "Task automation skills for angreal projects. Focused skills for running tasks, authoring tasks, arguments, ToolDescriptions, project setup, creating templates, and development patterns.",
   "author": {
     "name": "angreal",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -11,9 +11,9 @@ Task automation skills for angreal projects. Focused skills for each job to be d
 | `angreal-arguments` | "add arguments", "@angreal.argument", "add flags" | The @argument decorator |
 | `angreal-tool-descriptions` | "write ToolDescription", "AI guidance", "risk level" | Writing AI-friendly task descriptions |
 | `angreal-init` | "initialize angreal", "add angreal to project" | Adding angreal to existing projects |
-| `angreal-templates` | "create a template", "angreal.toml", "Tera templating" | Creating reusable templates for others |
+| `angreal-templates` | "create a template", "angreal.toml", "Tera templating", "in-place", "official templates" | Creating reusable templates for others (and consuming the official ones) |
 | `angreal-patterns` | "test tasks", "best practices", "error handling" | Testing, development, and documentation patterns |
-| `angreal-integrations` | "use Git in task", "create venv", "docker-compose", "render template" | Built-in Git, VirtualEnv, Docker, and Tera templating |
+| `angreal-integrations` | "use Git in task", "create venv", "docker-compose", "use Flox", "render template" | Built-in Git, VirtualEnv, Docker, Flox, and Tera templating |
 
 ## Auto-Activation
 
@@ -24,13 +24,15 @@ Skills automatically activate for projects containing a `.angreal/` directory.
 ### Via Claude Code Plugin System
 
 ```bash
-claude plugins add angreal
+# Add the angreal marketplace, then install the plugin
+/plugin marketplace add angreal/angreal
+/plugin install angreal@angreal-angreal
 ```
 
 ### Local Development
 
 ```bash
-claude --plugin-dir /path/to/angreal/skill
+claude --plugin-dir /path/to/angreal/plugin
 ```
 
 ## Skill Details
@@ -75,6 +77,8 @@ For creating reusable templates others can consume:
 - Template structure (`angreal.toml`, templated files)
 - Tera templating engine (variables, conditionals, loops)
 - Post-initialization scripts (`.angreal/init.py`)
+- In-place rendering (`angreal init <template> --in-place`)
+- The official angreal templates (`python`, `rust`, `data-science`, ...)
 - Publishing and sharing templates
 
 ### angreal-patterns
@@ -91,7 +95,8 @@ For built-in tool integrations:
 - `angreal.integrations.git.Git` - Repository operations
 - `angreal.integrations.venv.VirtualEnv` - Virtual environment management
 - `angreal.integrations.docker.DockerCompose` - Docker Compose operations
-- `@venv_required` decorator for automatic venv handling
+- `angreal.integrations.flox.Flox` - Cross-language environments and services
+- `@venv_required` / `@flox_required` decorators for automatic environment handling
 
 ## Quick Reference
 
@@ -115,9 +120,16 @@ angreal tree           # List all commands
 angreal tree --long    # Include ToolDescription prose
 ```
 
-## Version
+### Start a Project from an Official Template
 
-2.8.0
+```bash
+angreal init python          # github.com/angreal/python
+angreal init rust            # github.com/angreal/rust
+angreal init python --in-place   # render into the current directory
+```
+
+A bare name resolves to `https://github.com/angreal/<name>`. Browse the full,
+current catalog at [github.com/angreal](https://github.com/angreal).
 
 ## License
 

--- a/plugin/hooks/pre-compact.sh
+++ b/plugin/hooks/pre-compact.sh
@@ -40,9 +40,13 @@ ${TREE_OUTPUT}
 - \`angreal <command> --help\` — help for specific task
 
 ### Skills for Angreal Development
+- \`/angreal-usage\` - Running and discovering tasks
 - \`/angreal-authoring\` - Creating tasks
 - \`/angreal-arguments\` - Adding arguments
+- \`/angreal-tool-descriptions\` - Writing AI-friendly ToolDescriptions
 - \`/angreal-integrations\` - VirtualEnv, Git, Docker, Flox
+- \`/angreal-init\` - Adding angreal to an existing project
+- \`/angreal-templates\` - Templates + official templates (\`angreal init python\`, \`--in-place\`)
 - \`/angreal-patterns\` - Best practices
 EOF
 

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -50,11 +50,14 @@ ${TREE_OUTPUT}
 
 ## Available Skills
 When authoring or working with angreal tasks:
+- \`/angreal-usage\` - Running and discovering tasks
 - \`/angreal-authoring\` - Creating tasks and commands
 - \`/angreal-arguments\` - Adding arguments to tasks
+- \`/angreal-tool-descriptions\` - Writing AI-friendly ToolDescriptions
 - \`/angreal-integrations\` - Using VirtualEnv, Git, Docker, Flox integrations
+- \`/angreal-init\` - Adding angreal to an existing project
+- \`/angreal-templates\` - Creating templates and using the official ones (\`angreal init python\`, \`--in-place\`)
 - \`/angreal-patterns\` - Development best practices
-- \`/angreal-usage\` - Running and discovering tasks
 EOF
 
 # Escape the context for JSON (handle newlines and quotes)

--- a/plugin/skills/angreal-arguments/SKILL.md
+++ b/plugin/skills/angreal-arguments/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-arguments
 description: This skill should be used when the user asks to "add arguments to a task", "use @angreal.argument", "add flags to command", "make argument required", "add optional parameter", "use python_type", "handle multiple values", or needs guidance on the @argument decorator, argument types, flags, default values, or CLI argument handling in angreal tasks.
-version: 2.8.0
+version: 2.8.6
 ---
 
 # Angreal Arguments

--- a/plugin/skills/angreal-authoring/SKILL.md
+++ b/plugin/skills/angreal-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-authoring
 description: This skill should be used when the user asks to "create an angreal task", "write a task file", "add a command to angreal", "make a new task", "organize tasks with groups", "use @angreal.command", "use command_group", or needs guidance on task file structure, the @command decorator, command groups, naming conventions, or task organization within an existing angreal project.
-version: 2.8.0
+version: 2.8.6
 ---
 
 # Authoring Angreal Tasks

--- a/plugin/skills/angreal-init/SKILL.md
+++ b/plugin/skills/angreal-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-init
 description: This skill should be used when the user asks to "create an angreal project", "initialize angreal", "set up angreal", "add angreal to project", "start new angreal project", "create .angreal directory", or needs guidance on setting up angreal in a new or existing project, project templates, or initial task file structure.
-version: 2.8.0
+version: 2.8.6
 ---
 
 # Initializing Angreal Projects

--- a/plugin/skills/angreal-integrations/SKILL.md
+++ b/plugin/skills/angreal-integrations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-integrations
 description: This skill should be used when the user asks to "use Git in a task", "manage virtual environments", "use Docker Compose", "clone a repository", "create a venv", "run docker-compose", "use angreal.integrations", "render a template", "scaffold files", "generate files from template", "use render_template", "use render_directory", "use Flox", "flox environment", "cross-language environment", "flox services", "@flox_required", or needs guidance on the built-in Git, VirtualEnv, Docker, Flox, or Tera templating integrations available in angreal tasks.
-version: 2.8.1
+version: 2.8.6
 ---
 
 # Angreal Integrations

--- a/plugin/skills/angreal-patterns/SKILL.md
+++ b/plugin/skills/angreal-patterns/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-patterns
 description: This skill should be used when the user asks to "test angreal tasks", "mock angreal", "document tasks", "angreal best practices", "error handling in tasks", "subprocess patterns", "dry run mode", "verbose mode", or needs guidance on testing patterns, development workflows, documentation strategies, or common implementation patterns for angreal tasks.
-version: 2.8.0
+version: 2.8.6
 ---
 
 # Angreal Patterns

--- a/plugin/skills/angreal-templates/SKILL.md
+++ b/plugin/skills/angreal-templates/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-templates
-description: This skill should be used when the user asks to "create an angreal template", "make a project template", "build a reusable template", "share a template", "write angreal.toml", "use Tera templating", "template variables", "conditional templates", or needs guidance on creating templates that others can consume via `angreal init`, template configuration, Tera syntax, or publishing templates.
-version: 2.8.0
+description: This skill should be used when the user asks to "create an angreal template", "make a project template", "build a reusable template", "share a template", "write angreal.toml", "use Tera templating", "template variables", "conditional templates", "render a template in place", "use an official angreal template", "start a python/rust project with angreal", or needs guidance on creating templates that others can consume via `angreal init`, consuming the official angreal templates, in-place rendering, template configuration, Tera syntax, or publishing templates.
+version: 2.8.6
 ---
 
 # Creating Angreal Templates
@@ -18,6 +18,65 @@ angreal init /path/to/local/template
 ```
 
 This is different from `angreal-init` (adding angreal to existing projects) - templates create entirely new projects from scratch.
+
+## Official Templates
+
+The angreal team maintains a set of ready-to-use templates in the
+[github.com/angreal](https://github.com/angreal) organization. A **bare name**
+passed to `angreal init` resolves to `https://github.com/angreal/<name>`, so
+these can be used directly:
+
+```bash
+angreal init python      # Python project template
+angreal init rust        # Rust project template
+```
+
+| Template | `angreal init` | What it scaffolds |
+|----------|----------------|-------------------|
+| `python` | `angreal init python` | Standard Python project |
+| `python-gh` | `angreal init python-gh` | Python project wired for GitHub (Actions CI) |
+| `python-gl` | `angreal init python-gl` | Python project wired for GitLab (GitLab CI) |
+| `rust` | `angreal init rust` | Rust project: workspace layout, unified versioning, CI/CD, optional Tauri v2 desktop UI |
+| `data-science` | `angreal init data-science` | Modern data-science project with epoch-based notebook organization and scientific computing patterns |
+| `airflow` | `angreal init airflow` | Apache Airflow project scaffold |
+| `airflow-provider` | `angreal init airflow-provider` | Apache Airflow provider package |
+
+This list changes over time — browse [github.com/angreal](https://github.com/angreal)
+for the current, authoritative catalog (any non-fork repo containing an
+`angreal.toml` is a consumable template).
+
+Resolution order for `angreal init <name>`:
+1. A local path, if it exists
+2. A cached template in `~/.angrealrc/`, if present
+3. The GitHub repo `https://github.com/angreal/<name>`
+
+## Rendering In Place
+
+By default a template's single top-level templated directory (e.g.
+`{{ project_name }}/`) becomes a **new** project root inside the current
+directory. The `--in-place` / `-i` flag strips that top-level directory and
+renders its contents **directly into the current working directory** — useful
+for scaffolding into a folder you've already created (such as an existing git
+repository or a directory of planning notes):
+
+```bash
+mkdir my-project && cd my-project
+angreal init python --in-place        # contents land in ./, no extra root dir
+```
+
+In-place rendering requires the template to have **exactly one** top-level
+templated directory (it errors clearly on zero or multiple). Collisions with
+existing files reuse `--force` semantics: the command aborts unless `--force`
+is passed.
+
+### `angreal init` flags
+
+| Flag | Short | Effect |
+|------|-------|--------|
+| `--force` | `-f` | Render even if target paths/files already exist (overwrite) |
+| `--defaults` | `-d` | Use default values from `angreal.toml` without prompting |
+| `--in-place` | `-i` | Strip the template's top-level directory; render into the current directory |
+| `--values <FILE>` | | Supply values from a file, bypassing interactive prompts |
 
 ## Template Structure
 

--- a/plugin/skills/angreal-tool-descriptions/SKILL.md
+++ b/plugin/skills/angreal-tool-descriptions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-tool-descriptions
 description: This skill should be used when the user asks to "write a ToolDescription", "add AI guidance to task", "document task for AI", "set risk level", "write tool description prose", "guide AI agents", or needs guidance on angreal.ToolDescription, risk_level, writing effective descriptions for AI agent consumption, or making tasks AI-friendly.
-version: 2.8.0
+version: 2.8.6
 ---
 
 # Angreal ToolDescriptions

--- a/plugin/skills/angreal-usage/SKILL.md
+++ b/plugin/skills/angreal-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-usage
 description: This skill should be used when the user asks to "run an angreal task", "execute angreal command", "discover angreal tasks", "list angreal commands", "use angreal tree", "find available tasks", "what tasks are available", or needs guidance on running tasks, interpreting task output, task workflows, or choosing the right task for a job.
-version: 2.8.0
+version: 2.8.6
 ---
 
 # Using Angreal Tasks


### PR DESCRIPTION
Two related housekeeping changes after the 2.8.6 release.

## 1. Fix the release workflow (`ci:`)

The `Release to PyPI` job ran two twine commands:

```
twine upload --skip-existing dist/*   # uploads all wheels + sdist (correct)
twine upload --skip-existing *        # globs the repo root -> dies on Cargo.lock
```

The second command runs in the checked-out repo root, so its `*` glob picks up
`Cargo.lock` (and other repo files) and fails with
`InvalidDistribution: Unknown distribution format: 'Cargo.lock'`. This turned
the v2.8.6 (and v2.8.5) release jobs red **even though the package published
fine** via `dist/*`. The line is redundant, so it's removed.

Verified 2.8.6 is live on both [PyPI](https://pypi.org/project/angreal/2.8.6/)
and crates.io.

## 2. Freshen the Claude Code plugin (`docs(plugin):`)

- **Versions aligned to 2.8.6** across `marketplace.json`, `plugin.json`, and
  all 8 skills; removed the hardcoded README version footer that had drifted.
- **`--in-place` documented** in `angreal-templates` (new rendering section +
  full `angreal init` flag table) — matches the feature shipped in 2.8.6.
- **Official templates referenced**: `python`, `python-gh`, `python-gl`,
  `rust`, `data-science`, `airflow`, `airflow-provider`, with the bare-name ->
  `github.com/angreal/<name>` resolution and a pointer to the org for the live
  catalog.
- **README**: Flox added to the integrations summary; install instructions and
  local `--plugin-dir` path corrected; official-templates quick reference added.
- **Hooks**: session-start and pre-compact now list all 8 skills.
- Removed stray `plugin/.DS_Store`.
