### PR TITLE
Release 2.8.7: musl wheels + plugin refresh + Node 24 GHA bump

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
         run: plissken render
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,6 +144,37 @@ jobs:
           name: wheels-linux-x86_64
           path: dist
           overwrite: true
+  linux-musl:
+    runs-on: ubuntu-latest
+    name: linux-musl (${{ matrix.platform.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: x86_64-unknown-linux-musl
+            artifact: x86_64
+          - target: aarch64-unknown-linux-musl
+            artifact: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          architecture: x64
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          rust-toolchain: stable
+          target: ${{ matrix.platform.target }}
+          manylinux: musllinux_1_2
+          args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path crates/angreal/Cargo.toml
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-musl-${{ matrix.platform.artifact }}
+          path: dist
+          overwrite: true
+
   release-pypi:
     name: Release to PyPI
     runs-on: ubuntu-latest
@@ -152,6 +183,7 @@ jobs:
       - macos-x86_64
       - windows
       - linux
+      - linux-musl
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
@@ -182,6 +214,7 @@ jobs:
       - macos-x86_64
       - windows
       - linux
+      - linux-musl
     if: |
       startsWith(github.ref, 'refs/heads/cicd/') ||
       startsWith(github.ref, 'refs/heads/build') ||
@@ -213,6 +246,7 @@ jobs:
       - macos-x86_64
       - windows
       - linux
+      - linux-musl
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,8 @@ jobs:
   macos-x86_64:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           architecture: x64
@@ -37,7 +37,7 @@ jobs:
           pip install packaging pytest angreal --find-links dist --force-reinstall
           pytest
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-x86_64
           path: dist
@@ -46,8 +46,8 @@ jobs:
   macos-universal:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           architecture: x64
@@ -65,7 +65,7 @@ jobs:
           pip install packaging pytest angreal --find-links dist --force-reinstall
           pytest
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-universal
           path: dist
@@ -80,8 +80,8 @@ jobs:
           - target: x64
             interpreter: 3.10 3.11 3.12 3.13 3.14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           architecture: ${{ matrix.platform.target }}
@@ -107,7 +107,7 @@ jobs:
           pip install packaging pytest angreal --find-links dist --force-reinstall
           pytest
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: dist
@@ -115,8 +115,8 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           architecture: x64
@@ -139,7 +139,7 @@ jobs:
           pip install packaging pytest angreal --find-links dist --force-reinstall
           pytest
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-x86_64
           path: dist
@@ -156,8 +156,8 @@ jobs:
           - target: aarch64-unknown-linux-musl
             artifact: aarch64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           architecture: x64
@@ -169,7 +169,7 @@ jobs:
           manylinux: musllinux_1_2
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path crates/angreal/Cargo.toml
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-musl-${{ matrix.platform.artifact }}
           path: dist
@@ -186,12 +186,12 @@ jobs:
       - linux-musl
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: wheels-*
@@ -220,12 +220,12 @@ jobs:
       startsWith(github.ref, 'refs/heads/build') ||
       startsWith(github.ref, 'refs/heads/cicd-')
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: wheels-*
@@ -249,7 +249,7 @@ jobs:
       - linux-musl
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -70,7 +70,7 @@ jobs:
     name: "Build Verify"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -88,7 +88,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -99,7 +99,7 @@ jobs:
         continue-on-error: true
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install UV manually
@@ -133,7 +133,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -144,7 +144,7 @@ jobs:
         continue-on-error: true
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install UV manually
@@ -180,7 +180,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -191,7 +191,7 @@ jobs:
         continue-on-error: true
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install UV manually

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "angreal"
-version = "2.8.6"
+version = "2.8.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 default-members = ["crates/angreal"]
 
 [workspace.package]
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/angreal/angreal"

--- a/crates/angreal/Cargo.toml
+++ b/crates/angreal/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/angreal/angreal"
 license = "GPL-3.0-only"
 name = "angreal"
 repository = "https://github.com/angreal/angreal"
-version = "2.8.6"
+version = "2.8.7"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "angreal",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Task automation skills for angreal projects. Focused skills for running tasks, authoring tasks, arguments, ToolDescriptions, project setup, creating templates, and development patterns.",
   "author": {
     "name": "angreal",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -13,7 +13,8 @@ Task automation skills for angreal projects. Focused skills for each job to be d
 | `angreal-init` | "initialize angreal", "add angreal to project" | Adding angreal to existing projects |
 | `angreal-templates` | "create a template", "angreal.toml", "Tera templating", "in-place", "official templates" | Creating reusable templates for others (and consuming the official ones) |
 | `angreal-patterns` | "test tasks", "best practices", "error handling" | Testing, development, and documentation patterns |
-| `angreal-integrations` | "use Git in task", "create venv", "docker-compose", "use Flox", "render template" | Built-in Git, VirtualEnv, Docker, Flox, and Tera templating |
+| `angreal-integrations` | "use Git in task", "create venv", "docker-compose", "use Docker class", "use Flox", "render template" | Built-in Git, VirtualEnv, Docker, Flox, and Tera templating |
+| `angreal-mcp` | "expose tasks to Claude / Cursor", "set up MCP for angreal", "AI agent integration" | The built-in `angreal mcp` server and `.mcp.json` configuration |
 
 ## Auto-Activation
 
@@ -94,9 +95,17 @@ For built-in tool integrations:
 - `angreal.render_template()` / `angreal.render_directory()` - Tera templating for file scaffolding
 - `angreal.integrations.git.Git` - Repository operations
 - `angreal.integrations.venv.VirtualEnv` - Virtual environment management
+- `angreal.integrations.docker.Docker` - Low-level Docker client (containers, images, networks, volumes)
 - `angreal.integrations.docker.DockerCompose` - Docker Compose operations
 - `angreal.integrations.flox.Flox` - Cross-language environments and services
 - `@venv_required` / `@flox_required` decorators for automatic environment handling
+
+### angreal-mcp
+For making project tasks discoverable by AI assistants:
+- The built-in `angreal mcp` stdio server (Model Context Protocol)
+- `.mcp.json` configuration for Claude Code / Cursor / other MCP clients
+- How `ToolDescription` and `risk_level` flow into agent context
+- When to recommend MCP setup vs. relying on this plugin's SessionStart hook
 
 ## Quick Reference
 

--- a/plugin/hooks/pre-compact.sh
+++ b/plugin/hooks/pre-compact.sh
@@ -50,6 +50,7 @@ ${TREE_OUTPUT}
 - \`/angreal-init\` - Adding angreal to an existing project
 - \`/angreal-templates\` - Templates + official templates (\`angreal init python\`, \`--in-place\`)
 - \`/angreal-mcp\` - Expose tasks to AI assistants via \`angreal mcp\` server
+- \`/angreal-pre-commit\` - Wire angreal tasks into pre-commit hooks (pre-commit/pre-push)
 - \`/angreal-patterns\` - Best practices
 EOF
 

--- a/plugin/hooks/pre-compact.sh
+++ b/plugin/hooks/pre-compact.sh
@@ -35,9 +35,11 @@ read -r -d '' CONTEXT << EOF
 ${TREE_OUTPUT}
 \`\`\`
 
-### Quick Reference
-- \`angreal tree\` — list all tasks
-- \`angreal <command> --help\` — help for specific task
+### Operational Essentials
+
+**Top-level CLI**: \`tree\` / \`tree --long\` (discover), \`mcp\` (start MCP stdio server for AI clients), \`init <template>\` (scaffold; \`--in-place\` renders into cwd), \`alias create\`, \`completion\` (bash/zsh), \`-v\`/\`-vv\`/\`-vvv\` (verbosity), \`<command> --help\` (per-task help). Set \`ANGREAL_DEBUG=true\` to force debug logging; \`ANGREAL_NO_AUTO_COMPLETION=1\` to suppress completion install in CI.
+
+**Exit codes**: \`0\` success (also \`None\`/\`True\`); \`1\` general failure (also \`False\` or Angreal-level errors); \`56\` unhandled Python exception; \`N\` custom (task returns int \`N\` or raises \`SystemExit(N)\`). Propagate subprocess exit codes via \`return result.returncode\`.
 
 ### Skills for Angreal Development
 - \`/angreal-usage\` - Running and discovering tasks
@@ -47,6 +49,7 @@ ${TREE_OUTPUT}
 - \`/angreal-integrations\` - VirtualEnv, Git, Docker, Flox
 - \`/angreal-init\` - Adding angreal to an existing project
 - \`/angreal-templates\` - Templates + official templates (\`angreal init python\`, \`--in-place\`)
+- \`/angreal-mcp\` - Expose tasks to AI assistants via \`angreal mcp\` server
 - \`/angreal-patterns\` - Best practices
 EOF
 

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -42,6 +42,26 @@ This is an **angreal project** (detected \`.angreal\` directory).
 - \`angreal tree --long\` — list with full descriptions
 - \`angreal <command> --help\` — help for a specific task
 
+## Operational Essentials
+
+### Top-level CLI surface
+- \`angreal tree\` / \`angreal tree --long\` — discover tasks
+- \`angreal mcp\` — start MCP stdio server so AI clients can consume this project's task tree
+- \`angreal init <template>\` — scaffold a new project from a template (bare name → \`github.com/angreal/<name>\`); add \`--in-place\` / \`-i\` to render into the current directory instead of a new subdir
+- \`angreal alias create <name>\` — create a shell alias for an angreal command
+- \`angreal completion\` — install shell completion (auto-detects bash/zsh from \`\$SHELL\`)
+- \`-v\` / \`-vv\` / \`-vvv\` — increase verbosity. Set \`ANGREAL_DEBUG=true\` to force debug logging regardless of \`-v\` flags. Set \`ANGREAL_NO_AUTO_COMPLETION=1\` in CI to suppress completion auto-install.
+
+### Exit codes
+| Code | Meaning |
+|------|---------|
+| \`0\` | Success — also returned for \`None\` or \`True\` from the task function |
+| \`1\` | General failure — also returned for \`False\`, or when Angreal itself errors (missing task, no \`.angreal\`, template not found) |
+| \`56\` | Unhandled Python exception in the task (Angreal-specific — distinguishes task crashes from other failures) |
+| \`N\`  | Custom — task function returns int \`N\` (non-zero) or raises \`SystemExit(N)\` |
+
+Tasks should propagate subprocess exit codes (\`return result.returncode\`) rather than swallowing them.
+
 ## Available Tasks (with ToolDescriptions)
 
 \`\`\`
@@ -57,6 +77,7 @@ When authoring or working with angreal tasks:
 - \`/angreal-integrations\` - Using VirtualEnv, Git, Docker, Flox integrations
 - \`/angreal-init\` - Adding angreal to an existing project
 - \`/angreal-templates\` - Creating templates and using the official ones (\`angreal init python\`, \`--in-place\`)
+- \`/angreal-mcp\` - Exposing tasks to AI assistants via the built-in \`angreal mcp\` server
 - \`/angreal-patterns\` - Development best practices
 EOF
 

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -78,6 +78,7 @@ When authoring or working with angreal tasks:
 - \`/angreal-init\` - Adding angreal to an existing project
 - \`/angreal-templates\` - Creating templates and using the official ones (\`angreal init python\`, \`--in-place\`)
 - \`/angreal-mcp\` - Exposing tasks to AI assistants via the built-in \`angreal mcp\` server
+- \`/angreal-pre-commit\` - Wiring angreal tasks into pre-commit (pre-commit / pre-push) via \`angreal/pre-commit-angreal\`
 - \`/angreal-patterns\` - Development best practices
 EOF
 

--- a/plugin/skills/angreal-arguments/SKILL.md
+++ b/plugin/skills/angreal-arguments/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-arguments
-description: This skill should be used when the user asks to "add arguments to a task", "use @angreal.argument", "add flags to command", "make argument required", "add optional parameter", "use python_type", "handle multiple values", or needs guidance on the @argument decorator, argument types, flags, default values, or CLI argument handling in angreal tasks.
-version: 2.8.6
+description: This skill should be used when the user asks to "add arguments to a task", "use @angreal.argument", "add flags to command", "add -v flag to angreal task", "make argument required", "add optional parameter", "use python_type", "handle multiple values", "argparse for angreal task", "angreal cli args", or needs guidance on the @argument decorator, argument types, flags, default values, or CLI argument handling in angreal tasks.
+version: 2.8.7
 ---
 
 # Angreal Arguments

--- a/plugin/skills/angreal-authoring/SKILL.md
+++ b/plugin/skills/angreal-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-authoring
-description: This skill should be used when the user asks to "create an angreal task", "write a task file", "add a command to angreal", "make a new task", "organize tasks with groups", "use @angreal.command", "use command_group", or needs guidance on task file structure, the @command decorator, command groups, naming conventions, or task organization within an existing angreal project.
-version: 2.8.6
+description: This skill should be used when the user asks to "create an angreal task", "write a task file", "add a command to angreal", "make a new task", "organize tasks with groups", "use @angreal.command", "use command_group", "use angreal.group decorator", "add long_about to a task", "require an angreal version", "same command name in different groups", or needs guidance on task file structure, the @command decorator, command groups (`command_group` and `@group(...)`), `required_version()`, naming conventions, or task organization within an existing angreal project.
+version: 2.8.7
 ---
 
 # Authoring Angreal Tasks
@@ -51,6 +51,27 @@ def check_deps():  # Creates command "check-deps"
     pass
 ```
 
+### `long_about` for detailed help
+
+`about` is the one-liner shown in `angreal tree`. `long_about` is the multi-paragraph help shown by `angreal <command> --help`:
+
+```python
+@angreal.command(
+    name="deploy",
+    about="Deploy to an environment",
+    long_about="""
+Deploy the built artifacts to the target environment.
+
+Supports: development, staging, production.
+Reads credentials from $AWS_PROFILE; aborts if unset.
+""",
+)
+def deploy():
+    pass
+```
+
+`long_about` is for human CLI users. Pair it with a `tool=angreal.ToolDescription(...)` for AI agents — see the `angreal-tool-descriptions` skill.
+
 ## Command Groups
 
 Organize related commands with groups:
@@ -88,6 +109,52 @@ def docker_compose_up():
 ```
 
 Creates: `angreal docker compose up`
+
+### Same Command Name in Different Groups
+
+Since 2.8.5 the command registry is keyed by full path, so the same leaf name can safely appear under different groups without collision:
+
+```python
+test = angreal.command_group(name="test", about="Testing")
+docs = angreal.command_group(name="docs", about="Docs")
+
+@test()
+@angreal.command(name="all", about="Run all tests")
+def test_all(): ...
+
+@docs()
+@angreal.command(name="all", about="Build all docs")  # no collision
+def docs_all(): ...
+```
+
+Both `angreal test all` and `angreal docs all` work independently.
+
+### Alternative: `@angreal.group(name=...)` single-shot
+
+Instead of creating a reusable decorator with `command_group`, you can use the `@group(...)` decorator inline:
+
+```python
+@angreal.group(name="test", about="Testing commands")
+@angreal.command(name="all", about="Run all tests")
+def test_all():
+    pass
+```
+
+Use `command_group` when you have many commands sharing the group; use `@group` for one-offs.
+
+## Requiring a Minimum Angreal Version
+
+If a task file uses APIs added in a specific release, declare it at the top of the file so users get a clear error on older Angreal:
+
+```python
+import angreal
+
+angreal.required_version(">=2.8.7")
+
+# ...rest of the file
+```
+
+The specifier follows PEP 440 (`>=`, `==`, `<`, etc.). On mismatch, Angreal exits with a clear message before attempting to register the file's commands.
 
 ## Getting Project Root
 
@@ -165,11 +232,15 @@ def build():
 
 ### Return Codes
 
-| Code | Meaning |
-|------|---------|
-| `0` or `None` | Success |
-| `1` | General failure |
-| `2` | Invalid arguments |
+| Return value | Exit code | Notes |
+|--------------|-----------|-------|
+| `None` / `True` / `0` | `0` | Success |
+| `False` / `1` | `1` | General failure |
+| Any non-zero int `N` | `N` | Custom — e.g. `return 2` exits with code 2 |
+| `SystemExit(N)` raised | `N` | Intercepted and propagated |
+| Any other exception | `56` | Angreal-specific exit code for unhandled task exceptions; traceback is printed |
+
+Propagate subprocess exit codes via `return result.returncode` — don't translate them into 0/1 yourself unless you have a reason.
 
 ### Organization
 

--- a/plugin/skills/angreal-init/SKILL.md
+++ b/plugin/skills/angreal-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-init
-description: This skill should be used when the user asks to "create an angreal project", "initialize angreal", "set up angreal", "add angreal to project", "start new angreal project", "create .angreal directory", or needs guidance on setting up angreal in a new or existing project, project templates, or initial task file structure.
-version: 2.8.6
+description: This skill should be used when the user asks to "create an angreal project", "initialize angreal", "set up angreal", "add angreal to project", "start new angreal project", "create .angreal directory", "scaffold into existing project", "angreal init --in-place", "add angreal to existing repo", or needs guidance on setting up angreal in a new or existing project (hand-rolled `.angreal/` or via an official template), or the initial task file structure.
+version: 2.8.7
 ---
 
 # Initializing Angreal Projects
@@ -14,7 +14,24 @@ An angreal project is any directory containing a `.angreal/` subdirectory with t
 
 ## Quick Setup
 
-### 1. Create the .angreal Directory
+### Option A: Scaffold from an official template (recommended)
+
+For a fresh project or to add angreal to a directory you've already created, use one of the official templates:
+
+```bash
+# Fresh project (creates a new subdirectory)
+angreal init python
+
+# Add angreal into an existing project root (no extra subdir)
+cd my-existing-project
+angreal init python --in-place
+```
+
+`--in-place` / `-i` strips the template's top-level templated directory and renders directly into the current working directory — this is the canonical path for "add angreal to my existing repo." Add `--force` if existing files would be overwritten, `--defaults` to skip prompts, or `--values <file>` to supply variables non-interactively. See the `angreal-templates` skill for the full template catalog (`python`, `python-gh`, `python-gl`, `rust`, `data-science`, `airflow`, …).
+
+### Option B: Hand-roll the .angreal directory
+
+If no template matches or you want full control:
 
 ```bash
 mkdir .angreal

--- a/plugin/skills/angreal-integrations/SKILL.md
+++ b/plugin/skills/angreal-integrations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-integrations
-description: This skill should be used when the user asks to "use Git in a task", "manage virtual environments", "use Docker Compose", "clone a repository", "create a venv", "run docker-compose", "use angreal.integrations", "render a template", "scaffold files", "generate files from template", "use render_template", "use render_directory", "use Flox", "flox environment", "cross-language environment", "flox services", "@flox_required", or needs guidance on the built-in Git, VirtualEnv, Docker, Flox, or Tera templating integrations available in angreal tasks.
-version: 2.8.6
+description: This skill should be used when the user asks to "use Git in a task", "manage virtual environments", "use Docker Compose", "use the Docker class", "run docker container from task", "list docker containers in angreal", "clone a repository", "create a venv", "run docker-compose", "use angreal.integrations", "render a template", "scaffold files", "generate files from template", "use render_template", "use render_directory", "use Flox", "flox environment", "cross-language environment", "flox services", "@flox_required", or needs guidance on the built-in Git, VirtualEnv, Docker (compose or low-level client), Flox, or Tera templating integrations available in angreal tasks.
+version: 2.8.7
 ---
 
 # Angreal Integrations
@@ -126,9 +126,12 @@ project_name = context.get("project_name", "unknown")
 {# Comments #}
 
 {{ variable }}                    {# Variable substitution #}
-{{ name | upper }}                {# Filters: upper, lower, title, trim #}
-{{ items | length }}              {# Get length #}
-{{ value | default("fallback") }} {# Default value #}
+{{ name | upper }}                {# Common filters: upper, lower, title, trim, capitalize #}
+{{ path | replace(from="-", to="_") }} {# replace #}
+{{ name | slugify }}              {# url-safe slug #}
+{{ text | truncate(length=80) }}  {# truncate to N chars #}
+{{ items | length }}              {# get length #}
+{{ value | default(value="fallback") }} {# default if undefined #}
 
 {% if condition %}                {# Conditionals #}
 {% elif other %}
@@ -390,6 +393,49 @@ def setup():
     return 0
 ```
 
+## Docker (Low-Level Client)
+
+For working with individual containers, images, networks, or volumes — not multi-service stacks — use the `Docker` class. It's a thin client over the Docker engine and the right choice when `docker-compose.yml` would be overkill (one-off container runs, image cleanup, network inspection, volume management).
+
+### Import
+
+```python
+from angreal.integrations.docker import Docker
+from angreal.integrations.docker.container import Container, Containers
+from angreal.integrations.docker.image     import Image, Images
+from angreal.integrations.docker.network   import Network, Networks
+from angreal.integrations.docker.volume    import Volume, Volumes
+```
+
+### Basic Usage
+
+```python
+from angreal.integrations.docker import Docker
+
+d = Docker()                  # connects to the local Docker daemon
+print(d.version())            # dict — server version info
+print(d.ping())               # dict — health check
+print(d.info())               # dict — engine info
+print(d.data_usage())         # dict — disk usage breakdown
+
+# Interface methods return collection objects
+containers = d.containers()   # Containers
+images     = d.images()       # Images
+networks   = d.networks()     # Networks
+volumes    = d.volumes()      # Volumes
+```
+
+### When to use `Docker` vs `DockerCompose`
+
+| Use case | Use |
+|----------|-----|
+| Start/stop a multi-service stack defined in a yml | `DockerCompose` |
+| Inspect or manage individual containers/images/volumes | `Docker` |
+| Pull/tag/push a single image | `Docker.images()` |
+| Run a one-off container | `Docker.containers()` |
+
+`Docker()` requires the Docker daemon to be running locally — tasks should typically check `d.ping()` and fail gracefully if the daemon is unreachable.
+
 ## Docker Compose Integration
 
 Manage Docker Compose services from tasks.
@@ -617,8 +663,10 @@ def build():
 ```python
 from angreal.integrations.flox import Flox
 
-# Create instance
-flox = Flox(".")
+# Create instance — path defaults to the current directory
+flox = Flox()
+flox = Flox(".")           # explicit, equivalent
+flox = Flox("/path/to/env") # other location
 
 # Check availability
 if not Flox.is_available():

--- a/plugin/skills/angreal-mcp/SKILL.md
+++ b/plugin/skills/angreal-mcp/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: angreal-mcp
+description: This skill should be used when the user asks to "start the angreal mcp server", "expose angreal tasks to Claude / Cursor / an AI agent", "configure .mcp.json for angreal", "set up MCP for my angreal project", "connect angreal to an AI assistant", "what does angreal mcp do", "AI agent integration with angreal", or needs guidance on the built-in Model Context Protocol server (`angreal mcp`), what it exposes, how MCP clients should be configured to connect to it, and how `ToolDescription` and `risk_level` flow into agent context.
+version: 2.8.7
+---
+
+# Angreal MCP Server
+
+Angreal ships with a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server (`angreal mcp`) that injects a project's task tree into any connected MCP client. This is the canonical way to make a project's automation available to AI assistants without writing plugin code.
+
+## What It Is
+
+`angreal mcp` is a stdio-based MCP server implementing protocol version `2024-11-05`. It exposes **no MCP tools and no resources** — its only job is **context injection**.
+
+When an MCP client connects, the server's `initialize` response includes an `instructions` markdown document containing:
+
+1. A preamble: "Angreal tasks are authoritative for this project's operations."
+2. A decision rule: "If an angreal task covers the operation, use it instead of running the underlying tool directly."
+3. The full task tree (same content as `angreal tree --long`), including every command's name, argument signature, `about` line, and any `ToolDescription` prose + `risk_level`.
+
+That `instructions` field is loaded into the client's system context, so the AI agent knows about every task the project exposes from the moment it connects — no trial-and-error discovery, no manual onboarding.
+
+## Running the Server
+
+```bash
+angreal mcp
+```
+
+Must be run from inside an angreal project (a directory containing `.angreal/`). The server reads JSON-RPC from stdin and writes responses to stdout. It is not a long-lived daemon — MCP clients launch one process per connection.
+
+## Configuring an MCP Client
+
+### Claude Code (`.mcp.json`)
+
+In the project root or `~/.claude/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "angreal": {
+      "command": "angreal",
+      "args": ["mcp"],
+      "cwd": "/absolute/path/to/your/project"
+    }
+  }
+}
+```
+
+The `cwd` field is critical — it must point to the directory containing `.angreal/`. Without it the server has no project to introspect and will exit. Use an absolute path; MCP clients don't always resolve relative paths predictably.
+
+### Other MCP Clients
+
+Any MCP client that supports stdio servers will work. The pattern is the same: invoke `angreal mcp` with `cwd` set to the angreal project root. Consult the specific client's documentation for the exact config file location and schema.
+
+## Supported MCP Methods
+
+| Method | Behavior |
+|--------|----------|
+| `initialize` | Returns server info, capabilities, and the task instructions document |
+| `tools/list` | Returns `[]` (empty) — Angreal exposes context, not callable MCP tools |
+| `resources/list` | Returns `[]` |
+| `prompts/list` | Returns `[]` |
+| `ping` | Returns `{}` (health check) |
+
+Because no MCP tools are exposed, the agent does not "call" angreal through MCP — it learns *that* angreal exists and *what* tasks are available, then invokes `angreal <command>` through its own shell/bash tool. This is intentional: it keeps the agent's existing shell tooling as the single execution path and avoids duplicating every task as an MCP tool.
+
+## How `ToolDescription` Flows In
+
+Tasks decorated with `tool=angreal.ToolDescription(...)` get their full prose and `risk_level` included in the MCP `instructions` document. This is the primary reason to write ToolDescriptions:
+
+- **No `tool=`** → MCP sees just `name [args] - about line`
+- **With `tool=`** → MCP sees the full When-to-use / When-NOT / Examples / Recovery prose plus a `risk_level` tag
+
+See the `angreal-tool-descriptions` skill for how to write effective descriptions. The MCP server is what surfaces them; without `angreal mcp` (or `angreal tree --long`), nobody sees them.
+
+## When to Recommend the MCP Server
+
+Recommend setting it up when the user:
+
+- Wants their AI assistant to "just know" the project's commands
+- Is repeatedly correcting an agent that runs `pytest` directly instead of `angreal test python`
+- Is onboarding a new project to Claude Code / Cursor / similar and wants automation discoverability without writing a plugin
+- Asks "how do I make my agent use angreal tasks?"
+
+If the user is already inside a Claude Code session in an angreal project, the SessionStart hook in this plugin already injects similar context — `angreal mcp` is for *other* MCP clients (Cursor, Continue, custom agents) or for Claude Code instances where the angreal plugin isn't installed.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Server exits immediately on connect | `cwd` doesn't contain `.angreal/` |
+| Agent doesn't know about new tasks | MCP client caches `initialize` — restart the client after editing task files |
+| `instructions` is missing tool descriptions | Tasks lack `tool=angreal.ToolDescription(...)` — only `name`/`about` will be exposed |
+| `angreal: command not found` from MCP client | Use the absolute path to the `angreal` binary in the `command` field, or ensure the client's `PATH` includes it |

--- a/plugin/skills/angreal-mcp/SKILL.md
+++ b/plugin/skills/angreal-mcp/SKILL.md
@@ -6,19 +6,29 @@ version: 2.8.7
 
 # Angreal MCP Server
 
-Angreal ships with a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server (`angreal mcp`) that injects a project's task tree into any connected MCP client. This is the canonical way to make a project's automation available to AI assistants without writing plugin code.
+`angreal mcp` is a built-in [Model Context Protocol](https://modelcontextprotocol.io/) stdio server that injects a project's task tree into any connected MCP client at handshake time. It is the portable, client-agnostic way to make a project's automation discoverable to AI assistants.
 
-## What It Is
+## What It Actually Is (and Isn't)
 
-`angreal mcp` is a stdio-based MCP server implementing protocol version `2024-11-05`. It exposes **no MCP tools and no resources** — its only job is **context injection**.
+**It is**: structured context/prompt injection delivered over the MCP protocol. The server implements MCP 2024-11-05 and responds to five methods (`initialize`, `tools/list`, `resources/list`, `prompts/list`, `ping`). The entire useful payload is the `instructions` string returned in the `initialize` response — a markdown document containing:
 
-When an MCP client connects, the server's `initialize` response includes an `instructions` markdown document containing:
+1. A preamble: "Angreal IS the operational task orchestration system for this project."
+2. The decision rule: "Before running ANY build/test/lint/docs/deploy command, check the task list; use the angreal task if one exists."
+3. The full task tree (equivalent to `angreal tree --long`), including each command's name, argument signature, `about` line, and any `ToolDescription` prose + `risk_level`.
 
-1. A preamble: "Angreal tasks are authoritative for this project's operations."
-2. A decision rule: "If an angreal task covers the operation, use it instead of running the underlying tool directly."
-3. The full task tree (same content as `angreal tree --long`), including every command's name, argument signature, `about` line, and any `ToolDescription` prose + `risk_level`.
+That `instructions` field is a documented MCP feature meant exactly for this purpose — context an agent carries for the duration of the session. The client receives it once at connect, treats it as system-level guidance, and proceeds.
 
-That `instructions` field is loaded into the client's system context, so the AI agent knows about every task the project exposes from the moment it connects — no trial-and-error discovery, no manual onboarding.
+**It is NOT** a callable-tool MCP server. `tools/list`, `resources/list`, and `prompts/list` all return `[]`. The agent never calls back into the server after the handshake — it runs tasks the normal way (`angreal <command>` via its own shell tool).
+
+## Why No Callable Tools — This Is Deliberate
+
+Exposing each angreal task as an MCP tool would seem more "MCP-native," but it doesn't fit the workload:
+
+- **Angreal tasks tend to be long-running** (test suites, builds, deploys, doc generation). MCP tool-call semantics assume bounded, request/response interactions — long-running calls break client timeouts, lose streaming output, and create awkward reconnect/recovery edges that the agent has to handle.
+- **It would duplicate the CLI surface.** Every task would exist in two execution channels (shell and MCP tool call) with different error paths, different env handling, and different output capture. Agents would have to learn two ways to invoke the same thing.
+- **The shell is already the right channel.** Agents have a battle-tested bash/shell tool with streaming output, exit codes, env passthrough, and ergonomic interruption. There is no reason to re-implement any of that inside MCP.
+
+So Angreal splits the concerns cleanly: **MCP is the discovery channel, the shell is the execution channel.** The handshake teaches the agent what tasks exist and when to use them; the agent then invokes them through the channel that's actually good at long-running processes.
 
 ## Running the Server
 
@@ -57,12 +67,13 @@ Any MCP client that supports stdio servers will work. The pattern is the same: i
 | Method | Behavior |
 |--------|----------|
 | `initialize` | Returns server info, capabilities, and the task instructions document |
-| `tools/list` | Returns `[]` (empty) — Angreal exposes context, not callable MCP tools |
-| `resources/list` | Returns `[]` |
-| `prompts/list` | Returns `[]` |
-| `ping` | Returns `{}` (health check) |
+| `tools/list` | `[]` |
+| `resources/list` | `[]` |
+| `prompts/list` | `[]` |
+| `ping` | `{}` (health check) |
+| anything else | JSON-RPC `-32601 Method not found` |
 
-Because no MCP tools are exposed, the agent does not "call" angreal through MCP — it learns *that* angreal exists and *what* tasks are available, then invokes `angreal <command>` through its own shell/bash tool. This is intentional: it keeps the agent's existing shell tooling as the single execution path and avoids duplicating every task as an MCP tool.
+The `initialize` response is the only one that carries real payload. The empty `*/list` responses exist so MCP-conformant clients don't error out when they probe for tools/resources/prompts at startup.
 
 ## How `ToolDescription` Flows In
 

--- a/plugin/skills/angreal-patterns/SKILL.md
+++ b/plugin/skills/angreal-patterns/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-patterns
-description: This skill should be used when the user asks to "test angreal tasks", "mock angreal", "document tasks", "angreal best practices", "error handling in tasks", "subprocess patterns", "dry run mode", "verbose mode", or needs guidance on testing patterns, development workflows, documentation strategies, or common implementation patterns for angreal tasks.
-version: 2.8.6
+description: This skill should be used when the user asks to "test angreal tasks", "mock angreal", "document tasks", "angreal best practices", "error handling in tasks", "subprocess patterns", "dry run mode", "verbose mode", "debug an angreal task", "ANGREAL_DEBUG", "propagate subprocess returncode", "angreal exit code 56", or needs guidance on testing patterns, development workflows, documentation strategies, or common implementation patterns for angreal tasks.
+version: 2.8.7
 ---
 
 # Angreal Patterns
@@ -75,6 +75,18 @@ def test_task_output(capsys):
 ```
 
 ## Development Patterns
+
+### Angreal Debug Logging (`ANGREAL_DEBUG`)
+
+For debugging Angreal itself (task discovery, command registration, argument parsing, template rendering) — independent of any task-internal `-v` flag your task author wired up:
+
+```bash
+ANGREAL_DEBUG=true angreal test rust --unit-only
+```
+
+`ANGREAL_DEBUG=true` forces debug-level logging from the Angreal runtime and overrides CLI `-v`/`-vv` flags. Output goes to stderr. Use this when a task isn't being discovered, an argument isn't parsing as expected, or a template render fails silently.
+
+In CI, also set `ANGREAL_NO_AUTO_COMPLETION=1` to suppress the auto-install of shell completion on first run.
 
 ### Verbose Mode
 
@@ -367,6 +379,8 @@ def cmd(name):
 ## Composing Tasks
 
 ### Calling Other Task Functions
+
+These imports only resolve when `.angreal/` is on `sys.path` (Angreal puts it there during task execution, but pytest does not — see the `pytest.ini` snippet below to make tests work the same way):
 
 ```python
 from task_test import test_all

--- a/plugin/skills/angreal-pre-commit/SKILL.md
+++ b/plugin/skills/angreal-pre-commit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: angreal-pre-commit
+description: This skill should be used when the user asks to "add a pre-commit hook for angreal", "run angreal tasks before commit", "run angreal on pre-push", "set up pre-commit for tests/lint", "configure .pre-commit-config.yaml for angreal", "make tests run automatically before commit", or needs guidance on wiring [pre-commit](https://pre-commit.com/) to invoke angreal tasks (test, lint, format, etc.) at git lifecycle stages.
+version: 2.8.7
+---
+
+# Pre-commit Integration for Angreal
+
+The [`angreal/pre-commit-angreal`](https://github.com/angreal/pre-commit-angreal) repo provides a [pre-commit](https://pre-commit.com/) hook that runs angreal tasks at git lifecycle stages (pre-commit, pre-push, pre-merge-commit, etc.). Use this to make a project's angreal tasks the enforced quality gate before commits or pushes — no separate Makefile / npm script / shell wrapper.
+
+## Minimal Setup
+
+Add to the project's `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/angreal/pre-commit-angreal
+    rev: v0.1.0   # check the repo for the current tag — bump as needed
+    hooks:
+      - id: angreal
+        args:
+          - "test rust --unit-only"
+          - "test python"
+```
+
+Then install the git hook once per clone:
+
+```bash
+pre-commit install
+```
+
+Each entry in `args` is a **full angreal command string** (everything you'd type after `angreal`). They run serially and fail fast on the first non-zero exit, so order them cheapest-first (lint before tests, unit before integration).
+
+## Pinning the Angreal Version
+
+By default the hook installs the latest angreal. Pin it for reproducibility:
+
+```yaml
+hooks:
+  - id: angreal
+    additional_dependencies: ["angreal==2.8.7"]
+    args:
+      - "test rust --unit-only"
+```
+
+This matters when the project's tasks depend on Angreal features added in a specific release (e.g. ToolDescription, `--in-place`, `required_version`). Pin to the floor version your `.angreal/` files need.
+
+## Different Tasks at Different Stages
+
+```yaml
+hooks:
+  - id: angreal
+    alias: angreal-pre-commit
+    args: ["test rust --unit-only"]
+    stages: [pre-commit]
+  - id: angreal
+    alias: angreal-pre-push
+    args: ["test all"]
+    stages: [pre-push]
+```
+
+Common split:
+- **pre-commit**: fast checks only (lint, format, unit tests on changed components) — anything slower than ~10s frustrates contributors and gets bypassed.
+- **pre-push**: full suite (`angreal test all`, integration tests, doc build) — runs less often, so the cost is acceptable.
+
+Install both stages: `pre-commit install --hook-type pre-commit --hook-type pre-push`.
+
+## Why Use This Instead of Plain pre-commit Hooks
+
+- **One source of truth.** Tasks already exist in `.angreal/`; this just calls them. No reimplementation in YAML.
+- **Same command works locally and in the hook.** `angreal test python` runs the same way whether you type it, the hook invokes it, or CI runs it — no behavior drift between contexts.
+- **Tasks already encode project conventions.** Correct flags, working directory, environment setup. A hand-written hook would have to re-derive all of that.
+
+## When NOT to Use This
+
+- The check you want is genuinely outside angreal's scope (whitespace fixers, secret detectors, file-format validators) — use the dedicated pre-commit hooks for those (`trailing-whitespace`, `detect-secrets`, etc.) and let pre-commit-angreal handle only the project-specific tasks.
+- The angreal task is long-running (>30s) and would block every commit — move it to `pre-push` or CI, not `pre-commit`.
+
+## Tracking the Current rev
+
+The skill pins `v0.1.0` above (initial tag, cut 2026-05). For newer revs, run `gh api repos/angreal/pre-commit-angreal/tags --jq '.[].name'` or check the [tags page](https://github.com/angreal/pre-commit-angreal/tags). `pre-commit autoupdate` will also bump `rev:` to the latest tag automatically.

--- a/plugin/skills/angreal-templates/SKILL.md
+++ b/plugin/skills/angreal-templates/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-templates
 description: This skill should be used when the user asks to "create an angreal template", "make a project template", "build a reusable template", "share a template", "write angreal.toml", "use Tera templating", "template variables", "conditional templates", "render a template in place", "use an official angreal template", "start a python/rust project with angreal", or needs guidance on creating templates that others can consume via `angreal init`, consuming the official angreal templates, in-place rendering, template configuration, Tera syntax, or publishing templates.
-version: 2.8.6
+version: 2.8.7
 ---
 
 # Creating Angreal Templates

--- a/plugin/skills/angreal-tool-descriptions/SKILL.md
+++ b/plugin/skills/angreal-tool-descriptions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: angreal-tool-descriptions
-description: This skill should be used when the user asks to "write a ToolDescription", "add AI guidance to task", "document task for AI", "set risk level", "write tool description prose", "guide AI agents", or needs guidance on angreal.ToolDescription, risk_level, writing effective descriptions for AI agent consumption, or making tasks AI-friendly.
-version: 2.8.6
+description: This skill should be used when the user asks to "write a ToolDescription", "add AI guidance to task", "document task for AI", "set risk level", "write tool description prose", "guide AI agents", "MCP tool description", "make tasks AI-friendly", "expose task to angreal mcp", or needs guidance on angreal.ToolDescription, risk_level, or writing prose that the MCP server and `angreal tree --long` will show to agents.
+version: 2.8.7
 ---
 
 # Angreal ToolDescriptions
@@ -10,11 +10,12 @@ Write effective ToolDescription prose to guide AI agents using your tasks.
 
 ## Why ToolDescriptions Matter
 
-When AI agents discover tasks via `angreal tree --long`, they see:
-- Command name and arguments
-- **Your ToolDescription**
+ToolDescriptions are the contract between your tasks and any AI agent that consumes them. They surface in two places:
 
-The ToolDescription is the primary guidance for AI agents deciding whether and how to use your task. Think of it as a mini-prompt that teaches agents when and how to use your tool.
+1. **`angreal mcp`** — the built-in MCP stdio server injects every task's ToolDescription into the `initialize` response sent to connected MCP clients (Claude Code, etc.). This is the *primary* reason to write good descriptions: it's how agents discover what your project's tasks do without trial and error.
+2. **`angreal tree --long`** — the same prose shows up in human-facing CLI output.
+
+Think of a ToolDescription as a mini-prompt that teaches agents when and how to use your tool. Without one, the MCP server only exposes the command name and `about` line — agents have to guess.
 
 ## Basic Usage
 
@@ -65,6 +66,8 @@ angreal.ToolDescription(
 | `safe` | No destructive effects | Default. Build, test, lint tasks |
 | `read_only` | Only reads/reports | Status checks, info gathering |
 | `destructive` | May modify or delete | Deploy, clean, database migrations |
+
+An invalid string (typo, anything outside the three values above) is **not** an error — Angreal logs a warning and silently falls back to `"safe"`. Watch for this when you intended `"destructive"` and got `"safe"` instead: check `angreal tree --long` to confirm the risk level rendered correctly.
 
 ## Structuring Descriptions
 

--- a/plugin/skills/angreal-usage/SKILL.md
+++ b/plugin/skills/angreal-usage/SKILL.md
@@ -1,139 +1,107 @@
 ---
 name: angreal-usage
-description: This skill should be used when the user asks to "run an angreal task", "execute angreal command", "discover angreal tasks", "list angreal commands", "use angreal tree", "find available tasks", "what tasks are available", or needs guidance on running tasks, interpreting task output, task workflows, or choosing the right task for a job.
-version: 2.8.6
+description: Consult before running ANY development operation in an angreal project — tests, build, lint, format, type-check, docs, deploy, clean, install, migrate, release. Also for "run an angreal task", "execute angreal command", "discover angreal tasks", "use angreal tree", "what tasks are available", "angreal mcp", "angreal init", "angreal alias", "angreal completion", "verbose angreal output", "ANGREAL_DEBUG", or when chaining tasks, picking the right task for a job, or interpreting an angreal exit code. The operational essentials (top-level CLI surface, exit codes, debug env vars) are already injected by the SessionStart/PreCompact hook — this skill is the deep dive on group nesting, workflow composition, and task selection heuristics.
+version: 2.8.7
 ---
 
-# Using Angreal Tasks
+# Using Angreal Tasks (Deep Dive)
 
-Learn to discover, run, and chain angreal tasks effectively.
+The session-start hook already injects the task tree, the "use angreal first" rule, the top-level CLI surface (`tree`, `mcp`, `init`, `alias`, `completion`, `-v`, `--help`), the exit-code table, and the debug env vars. This skill covers what doesn't fit in that always-present preamble: argument syntax, group nesting, workflow composition, and how to choose between tasks.
 
-## Prerequisites
+## Argument Syntax
 
-- Working within an angreal project (has `.angreal/` directory)
-- `angreal` CLI installed and available
+**Flags** (boolean switches — no value):
 
-## Discovering Tasks
-
-### Quick Discovery
-
-```bash
-angreal tree
-```
-
-Shows all commands with arguments and short descriptions:
-
-```
-dev: development utilities
-  check-deps - Verify required development tools are installed
-test: commands for testing the application
-  all - Run complete test suite
-  rust [--unit-only] - Run Rust tests
-docs: commands for documentation
-  build [--draft] - Build documentation site
-```
-
-### Detailed Discovery (AI Guidance)
-
-```bash
-angreal tree --long
-```
-
-Includes full ToolDescription prose for each command:
-- **When to use** - Appropriate scenarios
-- **When NOT to use** - Situations to avoid
-- **Examples** - Concrete invocations
-- **Risk level** - safe, read_only, or destructive
-
-### Traditional Help
-
-```bash
-angreal --help              # List all commands
-angreal test rust --help    # Help for specific command
-```
-
-## Running Tasks
-
-### Basic Invocation
-
-```bash
-angreal <group> <command> [arguments]
-
-# Examples
-angreal test all
-angreal test rust --unit-only
-angreal build --release
-angreal docs serve --prod
-```
-
-### Arguments
-
-**Flags** (boolean switches):
 ```bash
 angreal build --release
 angreal test rust --unit-only
 ```
 
-**Value arguments**:
+**Value arguments** (both forms work unless the task uses `require_equals`):
+
 ```bash
 angreal deploy --version v1.2.3
 angreal test completion --shell=bash
 ```
 
-## Output and Exit Codes
-
-- Exit code `0` = success
-- Non-zero exit code = failure
+**Multi-value arguments** (repeat the flag):
 
 ```bash
-angreal test all && angreal deploy  # Chain with &&
+angreal compile --file a.txt --file b.txt
 ```
 
-## Common Workflows
-
-### Before Committing
+**Short flags** chain with single-char names:
 
 ```bash
-angreal test unit      # Fast unit tests first
-angreal test all       # Full suite if units pass
-angreal lint check     # Check code style
+angreal build -vj 8        # if -v and -j are both single-char short flags
 ```
 
-### Release Process
+When in doubt, run `angreal <command> --help` — it always shows the exact accepted syntax.
+
+## Task Groups and Nesting
+
+Tasks are organized hierarchically. Two-level nesting is common; deeper nesting works but is rare.
 
 ```bash
-angreal test all           # Ensure tests pass
-angreal build --release    # Create release build
-angreal docs build         # Update documentation
-angreal deploy staging     # Deploy to staging
+angreal test rust              # single group
+angreal docker compose up      # nested groups
+angreal docs build --draft     # group + flag
 ```
 
-### Debugging
+Groups are namespaces, not tasks themselves — `angreal docker` with no subcommand will list the docker group's commands. Use `angreal tree` to see the full tree at a glance.
 
-```bash
-angreal test <specific-test> --verbose  # Verbose output
-# Check stdout/stderr for error details
-# Fix issue, re-run specific test
-angreal test all                        # Verify no regressions
-```
-
-## Task Groups
-
-Tasks are organized by function:
-
-| Group | Purpose |
-|-------|---------|
-| `dev` | Development utilities |
-| `test` | Testing commands |
-| `docs` | Documentation |
-| `build` | Build and compilation |
-| `deploy` | Deployment and release |
-
-Groups can nest: `angreal docker compose up`
+A single command name can legitimately appear under multiple groups (e.g. `angreal test all` and `angreal docs all`) — Angreal 2.8.5+ keys the registry by full path so this is collision-free.
 
 ## Choosing the Right Task
 
-1. Run `angreal tree` to see available commands
-2. Use `angreal tree --long` for detailed guidance
-3. Start with read-only tasks to explore safely
-4. Trust ToolDescriptions - they're written to guide you
+When `angreal tree --long` shows several candidates, the `ToolDescription` blocks include `risk_level` and "When to use / When NOT to use" guidance. Prefer:
+
+1. The task whose **"When to use"** lists the current scenario.
+2. **`read_only`** over `safe` over `destructive` when exploring or unsure.
+3. The **narrowest** task that does the job (e.g. `test rust --unit-only` over `test all` when you only changed Rust unit code).
+4. **Composite tasks** (`test all`, `ci`) when the user asks for "the full check" or before a release.
+
+If two tasks look equally appropriate, the one with the more detailed `ToolDescription` is usually the canonical entry point — task authors put effort into the one they want agents to pick.
+
+## Common Workflow Compositions
+
+### Pre-commit / pre-push
+
+```bash
+angreal lint check && angreal test all
+```
+
+Chain with `&&` so a failure halts the chain. Each task's non-zero exit propagates naturally.
+
+### Release cut
+
+```bash
+angreal test all \
+  && angreal build --release \
+  && angreal docs build \
+  && angreal deploy staging
+```
+
+Stop at the first failure. For destructive steps (`deploy`), confirm the user wants to proceed rather than chaining blindly.
+
+### Debugging a failing task
+
+```bash
+ANGREAL_DEBUG=true angreal test rust --unit-only -v
+```
+
+`ANGREAL_DEBUG=true` enables Angreal's own debug logging (task discovery, registration, argument parsing). The task-internal `-v` flag — if the task author wired one — controls the task's own verbosity. The two are independent.
+
+### Iterating on a single test
+
+If `angreal test python` runs the whole pytest suite but you want a single test, check whether the task accepts a pattern argument (`angreal test python --help`). If not, fall through to the underlying tool (`pytest tests/test_foo.py::test_bar`) — this is one of the rare cases where bypassing angreal is correct.
+
+## When to Bypass Angreal
+
+The "always use angreal" rule has a few legitimate exceptions:
+
+- **Single-file or filter-style invocations** the angreal task doesn't expose (e.g. running one pytest node).
+- **Inspection commands** that exist outside the project's automation contract (`git log`, `ls`, `cat`).
+- **One-off exploration** the user explicitly asks for ("just run `cargo check` directly").
+
+Default behavior is still: check `angreal tree` first; only bypass when the task genuinely can't express what's needed.


### PR DESCRIPTION
Prep for the 2.8.7 release cut.

## Summary

- **aarch64 + x86_64 musl wheels** — new `linux-musl` matrix job in `release.yaml` builds `musllinux_1_2` wheels for both architectures via `PyO3/maturin-action` (QEMU handles the aarch64 cross-build). Wired into `release-pypi`, `test-pypi`, and `release-cargo` needs lists.
- **Version bump 2.8.6 → 2.8.7** across `Cargo.toml`, `crates/angreal/Cargo.toml`, `Cargo.lock`, and `plugin/.claude-plugin/plugin.json`.
- **Plugin skills refreshed** for 2.8.7:
  - SessionStart + PreCompact hooks now inline an "Operational Essentials" block (top-level CLI surface, exit codes 0/1/56/N, `ANGREAL_DEBUG`, `ANGREAL_NO_AUTO_COMPLETION`) — guaranteed present whenever `.angreal/` exists, not gated on skill-description matching.
  - `angreal-usage` trimmed to deep-dive role (group nesting, workflow composition, task-selection heuristics); description widened to fire on operation intent ("run tests", "build", "lint") rather than only the word "angreal".
  - **New `angreal-mcp` skill** — covers the built-in `angreal mcp` stdio server, `.mcp.json` configuration, and the deliberate design choice to deliver task context via the MCP `instructions` field rather than exposing tasks as callable MCP tools (long-running tasks break MCP tool-call timeout semantics).
  - **New `angreal-pre-commit` skill** — covers the `angreal/pre-commit-angreal` hook for wiring angreal tasks into pre-commit / pre-push. Tag `v0.1.0` of pre-commit-angreal cut to match the README's example.
  - Other skills updated per audit: `Docker` low-level class (separate from `DockerCompose`), `@angreal.group(name=)`, `required_version()`, `long_about`, ToolDescription MCP framing, `--in-place` as the canonical add-angreal-to-existing-project path, exit-code table corrected, ANGREAL_DEBUG section, expanded Tera filter examples.
- **Node 20 GHA actions bumped** to Node 24-capable majors (`checkout` v4→v6, `setup-python` v4/v5→v6, `upload-artifact` v4→v7, `download-artifact` v4→v8) across `release.yaml`, `test.yaml`, `docs.yaml`. GitHub flagged the old versions for deprecation in June 2026.

## Test plan

- [x] Dry-run release workflow on this branch: previous run (`f5649d6`) was green — all six wheel jobs succeeded (linux, linux-musl x86_64, linux-musl aarch64, macos-x86_64, macos-universal, windows x64) and Test PyPI upload succeeded.
- [ ] Current in-flight run on `56d3fb7` validates the GHA action bumps don't break the build path. https://github.com/angreal/angreal/actions/runs/26585302293
- [ ] After merge, tag `v2.8.7` to trigger the real PyPI + Cargo publish on the release workflow's `release: published` trigger.