### PR TITLE
feat(oci): OCI template targets and angreal.integrations.oci

### DIFF
--- a/.angreal/task_test.py
+++ b/.angreal/task_test.py
@@ -151,7 +151,18 @@ angreal test rust --integration-only  # Run integration tests only
     takes_value=False,
     is_flag=True
 )
-def rust_tests_combined(unit_only: bool = False, integration_only: bool = False):
+@angreal.argument(
+    name="filter",
+    long="filter",
+    help="only run tests whose name matches this filter (cargo test <FILTER>)",
+    required=False,
+    takes_value=True
+)
+def rust_tests_combined(
+    unit_only: bool = False,
+    integration_only: bool = False,
+    filter: str = None,
+):
     """
     Run Rust unit and integration tests
     """
@@ -161,16 +172,16 @@ def rust_tests_combined(unit_only: bool = False, integration_only: bool = False)
 
     if integration_only:
         print("Running Rust integration tests only...")
-        return integration_rust_tests()
+        return integration_rust_tests(filter)
     elif unit_only:
         print("Running Rust unit tests only...")
-        return unit_rust_tests()
+        return unit_rust_tests(filter)
     else:
         print("Running all Rust tests...")
-        result = unit_rust_tests()
+        result = unit_rust_tests(filter)
         if result:
             return result
-        return integration_rust_tests()
+        return integration_rust_tests(filter)
 
 
 def _maturin_develop():
@@ -202,35 +213,35 @@ def _maturin_develop():
     return 0
 
 
-def integration_rust_tests():
+def integration_rust_tests(filter: str = None):
     """
     Run the Rust integration tests
     """
     rc = _maturin_develop()
     if rc != 0:
         return rc
-    result = subprocess.run(
-        ["cargo", "test", "--workspace", "--test", "integration", "-v",
-         "--", "--nocapture", "--test-threads=1"],
-        cwd=str(project_root)
-    )
+    cmd = ["cargo", "test", "--workspace", "--test", "integration", "-v"]
+    if filter:
+        cmd.append(filter)
+    cmd += ["--", "--nocapture", "--test-threads=1"]
+    result = subprocess.run(cmd, cwd=str(project_root))
     if result.returncode != 0:
         return result.returncode
     return 0
 
 
-def unit_rust_tests():
+def unit_rust_tests(filter: str = None):
     """
     Run the Rust unit tests
     """
     rc = _maturin_develop()
     if rc != 0:
         return rc
-    result = subprocess.run(
-        ["cargo", "test", "--workspace", "--lib", "-v",
-         "--", "--nocapture", "--test-threads=1"],
-        cwd=str(project_root)
-    )
+    cmd = ["cargo", "test", "--workspace", "--lib", "-v"]
+    if filter:
+        cmd.append(filter)
+    cmd += ["--", "--nocapture", "--test-threads=1"]
+    result = subprocess.run(cmd, cwd=str(project_root))
     if result.returncode != 0:
         return result.returncode
     return 0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -187,11 +187,6 @@ jobs:
     name: "OSX Tests (Python ${{ matrix.python-version }})"
     runs-on: macos-14
     needs: [pre-commit, build-verification]
-    # Exercise the real HTTPS registry path on macOS (native-tls -> Apple
-    # SecureTransport). Service containers aren't available here, so instead of
-    # a localhost registry this runs the opt-in public-registry HTTPS smoke test.
-    env:
-      ANGREAL_OCI_HTTPS_SMOKE: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -221,6 +216,14 @@ jobs:
           angreal test rust --unit-only
           angreal test python
           angreal --version
+      # Hard gate: the real HTTPS registry path on macOS (native-tls -> Apple
+      # SecureTransport) that `angreal init oci://...` depends on. Isolated to
+      # just the smoke test so it is NOT swallowed by the continue-on-error
+      # integration step below (which also runs flaky git-SSH tests).
+      - name: OCI HTTPS smoke (macOS TLS gate)
+        env:
+          ANGREAL_OCI_HTTPS_SMOKE: "1"
+        run: angreal test rust --integration-only --filter test_https_public_registry_smoke
       - name: Integration Tests
         continue-on-error: true
         run: angreal test rust --integration-only

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,8 +86,10 @@ jobs:
     # Local OCI registry for the oci:// template + angreal.integrations.oci tests.
     # Service containers are Linux-only, so this coverage runs here; the same
     # tests skip on the macOS/Windows jobs (ANGREAL_OCI_TEST_REGISTRY unset).
+    # ANGREAL_OCI_HTTPS_SMOKE also exercises the HTTPS path (OpenSSL here).
     env:
       ANGREAL_OCI_TEST_REGISTRY: localhost:5000
+      ANGREAL_OCI_HTTPS_SMOKE: "1"
     services:
       registry:
         image: registry:2
@@ -185,6 +187,11 @@ jobs:
     name: "OSX Tests (Python ${{ matrix.python-version }})"
     runs-on: macos-14
     needs: [pre-commit, build-verification]
+    # Exercise the real HTTPS registry path on macOS (native-tls -> Apple
+    # SecureTransport). Service containers aren't available here, so instead of
+    # a localhost registry this runs the opt-in public-registry HTTPS smoke test.
+    env:
+      ANGREAL_OCI_HTTPS_SMOKE: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,6 +83,16 @@ jobs:
     name: "Linux Tests (Python ${{ matrix.python-version }})"
     runs-on: ubuntu-latest
     needs: [pre-commit, build-verification]
+    # Local OCI registry for the oci:// template + angreal.integrations.oci tests.
+    # Service containers are Linux-only, so this coverage runs here; the same
+    # tests skip on the macOS/Windows jobs (ANGREAL_OCI_TEST_REGISTRY unset).
+    env:
+      ANGREAL_OCI_TEST_REGISTRY: localhost:5000
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     strategy:
       fail-fast: false
       matrix:

--- a/.metis/initiatives/ANG-I-0010/initiative.md
+++ b/.metis/initiatives/ANG-I-0010/initiative.md
@@ -174,6 +174,12 @@ docs):
 - **musl + TLS**: CI builds musl wheels. Reuse the existing vendored-OpenSSL
   native-tls backend for `oci-client` (its default) rather than adding rustls —
   one TLS stack, already proven on musl. Confirm the compile early.
+- **macOS TLS (RESOLVED)**: `native-tls` resolves to Apple SecureTransport on
+  macOS (not the vendored OpenSSL). Verified working: the `ANGREAL_OCI_HTTPS_SMOKE`
+  integration test does a live anonymous `list_tags` over HTTPS against Docker
+  Hub and passes on macOS (SecureTransport) locally. CI runs this smoke on the
+  macOS job every run (and on Linux, exercising the OpenSSL HTTPS path); the
+  localhost round-trip tests only cover HTTP.
 - **tokio footprint**: first async dep; keep it feature-minimal (`rt`,
   `macros`) and confined to the oci module.
 - **Registry test harness**: integration tests need a throwaway registry.

--- a/.metis/initiatives/ANG-I-0010/initiative.md
+++ b/.metis/initiatives/ANG-I-0010/initiative.md
@@ -1,0 +1,182 @@
+---
+id: oci-support
+level: initiative
+title: "OCI Support: Template Targets and Plugin Integration"
+short_code: "ANG-I-0010"
+created_at: 2026-07-24T00:00:00.000000+00:00
+updated_at: 2026-07-24T00:00:00.000000+00:00
+parent: ANG-V-0001
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/completed"
+
+
+exit_criteria_met: true
+estimated_complexity: M
+initiative_id: oci-support
+---
+
+# OCI Support Initiative
+
+## Context **[REQUIRED]**
+
+A feature request — "We should support OCI" — asks angreal to speak
+[OCI](https://opencontainers.org/) (Open Container Initiative) registries. In
+context this means two related but distinct capabilities:
+
+1. **OCI template targets.** Let `angreal init` consume a template packaged and
+   stored as an OCI artifact in a registry (GHCR, Docker Hub, ECR, self-hosted
+   Zot/Harbor, …). Registries have become a general-purpose artifact
+   distribution mechanism (Helm charts, WASM modules, Homebrew bottles all ship
+   as OCI artifacts), and templates fit the same model: versioned, content-
+   addressed, access-controlled, cache-friendly.
+
+2. **An OCI plugin interface.** Expose basic OCI registry operations to task
+   authors as `angreal.integrations.oci`, mirroring the existing
+   `angreal.integrations.{git,venv,flox,docker}` modules, so tasks can pull and
+   push artifacts, list tags, and authenticate against registries.
+
+Both halves share one Rust core: an OCI client wrapper. `init` consumes its pull
+path; the Python binding exposes the fuller surface.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- `angreal init oci://<registry>/<repo>:<tag>` resolves, pulls, caches, and
+  renders a template artifact, reusing the existing render pipeline unchanged.
+- A pure-Rust OCI core (`crates/angreal/src/integrations/oci/`) built on the
+  `oci-client` crate: pull, push, list tags, and registry auth.
+- Define an **angreal template artifact convention** (a gzipped tar of the
+  template directory carried in an OCI layer with a dedicated media type) and a
+  **push** path so authors can publish templates, not only consume them.
+- Expose `angreal.integrations.oci` with a minimal, focused surface:
+  `pull`, `push`, `list_tags` (`tags`), and `login`.
+- Registry auth: anonymous for public repos, Basic (username/password or token),
+  and Docker `config.json` credentials where present.
+- Default (non-`oci://`) `init` behavior remains byte-for-byte unchanged.
+- Cover with Rust unit/integration tests, Python functional tests, and docs.
+
+**Non-Goals:**
+- Running a container / talking to a Docker daemon — that is the separate
+  existing `angreal.integrations.docker` (Bollard) surface. This initiative is
+  registry/artifact operations, daemonless.
+- A rich registry-management surface (manifest inspect, cross-registry copy, tag
+  delete, referrers/signatures). May follow later; not in the initial cut.
+- Cosign/Notation signature verification of pulled artifacts (future hardening).
+- Publishing angreal's own official templates as OCI artifacts (separate ops
+  work once the mechanism exists).
+
+## Design Decisions (confirmed with maintainer)
+
+1. **Backend — pure-Rust `oci-client`.** Bundle the `oci-client` crate rather
+   than shelling out to `oras`/`skopeo`/`docker`. This matches angreal's
+   self-contained philosophy (bundled `git2`/libgit2, bundled `uv`) — no
+   external binary required at runtime. Trade-off: `oci-client` is async
+   (tokio), so this introduces angreal's first async dependency, bridged to the
+   existing synchronous call paths with a `block_on` on a small runtime.
+2. **Scope — pull + push.** Define the template artifact convention and provide
+   a push path so the authoring loop is closed end-to-end, not pull-only.
+3. **Plugin surface — minimal.** `pull` / `push` / `tags` / `login`. Expand
+   later based on real demand rather than speculatively.
+
+## Detailed Design **[REQUIRED]**
+
+### Shared Rust core — `crates/angreal/src/integrations/oci/mod.rs`
+A thin synchronous wrapper over `oci-client` (`oci-client = "0.17"`), following
+the shape of the `git`/`flox`/`uv` integration modules:
+
+- `Oci` (or free functions) with:
+  - `pull_artifact(reference, dest, auth) -> Result<PathBuf>` — pull the
+    manifest, fetch the template layer(s), unpack the gzipped tar into `dest`.
+  - `push_artifact(reference, src_dir, auth) -> Result<()>` — tar+gzip
+    `src_dir`, assemble a manifest with the angreal template media type, push
+    config + layer + manifest.
+  - `list_tags(repository, auth) -> Result<Vec<String>>`.
+  - Auth resolution: `RegistryAuth::Anonymous`, `RegistryAuth::Basic`, and a
+    helper that reads Docker `~/.docker/config.json` credentials.
+- Async is contained here: create a current-thread tokio runtime and
+  `block_on` each op so all public methods are synchronous to the rest of
+  angreal. (Add `tokio = { version = "1", features = ["rt", "macros"] }`.)
+
+**Template artifact convention (v1):**
+- Config media type: `application/vnd.angreal.template.config.v1+json`
+  (small JSON: angreal version, template name, created-at).
+- Layer media type: `application/vnd.angreal.template.layer.v1.tar+gzip`
+  (gzipped tar of the template directory — the same tree `init` renders).
+- Artifact manifest per the OCI image-manifest spec so any OCI-compliant
+  registry accepts it and `oras`/`skopeo` can interoperate.
+
+### `init` integration — `crates/angreal/src/init.rs`
+- `get_scheme` (`init.rs:115`): short-circuit `oci://` **before** git-url
+  parsing (the same pattern as the existing Windows-path short-circuit), class
+  returning `"oci"`.
+- `init` dispatch (`init.rs:40`): add an `"oci"` arm calling a new
+  `handle_oci_template(reference, &angreal_home)` that pulls into a cache path
+  under `~/.angrealrc/oci/<registry>/<repo>/<tag>/` and returns it, after which
+  the existing `render_template` path runs unchanged.
+- Caching mirrors git templates: reuse the cached unpack if present (content is
+  content-addressed by digest; re-pull is cheap and can refresh on tag).
+
+### Python binding — `crates/angreal/src/python_bindings/integrations/oci.rs`
+- New `#[pyclass] Oci` + `#[pymodule] oci` wrapping the core, registered in
+  `python_bindings/integrations/mod.rs` and added to `sys.modules` as
+  `angreal.integrations.oci` (exactly as `git`/`venv`/`flox` are wired at
+  `python_bindings/integrations/mod.rs:31`).
+- Surface: `Oci.pull(reference, dest=None)`, `Oci.push(reference, path)`,
+  `Oci.tags(repository)`, `Oci.login(registry, username, password)`.
+- Errors surface as Python exceptions via the existing error-formatting path.
+
+### Dependencies
+- `oci-client = "0.17"` and `tokio` (rt + macros) added to
+  `crates/angreal/Cargo.toml`. Confirm `extension-module` feature interaction
+  and musl build (CI already builds musl wheels).
+- **TLS backend — reuse the existing one, do not add a second.** angreal already
+  vendors OpenSSL (`openssl = { features = ["vendored"] }`) and `reqwest`/`git2`
+  use native-tls against it; this already builds static on musl in CI. Configure
+  `oci-client` with its **default `native-tls`** feature so it rides the same
+  vendored OpenSSL — one TLS backend, nothing new on musl. Do **not** enable
+  `oci-client`'s `rustls-tls` feature, which would pull rustls in alongside the
+  existing OpenSSL. Task 1 only needs to confirm `oci-client` (default features)
+  compiles against the vendored OpenSSL under musl.
+
+## Alternatives Considered **[REQUIRED]**
+
+- **Shell out to `oras`/`skopeo`/`docker`.** Rejected: adds a hard runtime
+  dependency users must install and breaks the self-contained model angreal
+  holds elsewhere (git2, uv). Pure-Rust keeps single-binary distribution.
+- **Reuse the existing Docker (Bollard) integration.** Rejected: that is a
+  Docker *daemon* client for containers, not daemonless *registry/artifact*
+  operations, and would force a running Docker daemon for template pulls.
+- **Pull-only (publish via external `oras`).** Rejected in favor of shipping a
+  push path so template authoring is a first-class, self-contained workflow.
+
+## Implementation Plan **[REQUIRED]**
+
+Proposed task decomposition (pending maintainer approval before creating task
+docs):
+
+1. **OCI Rust core** — `integrations/oci/` module: `oci-client` + tokio bridge,
+   pull/push/list_tags, auth (anonymous/basic/docker-config), the template
+   artifact media-type convention, and unit tests. Add deps to `Cargo.toml`.
+2. **`init` OCI template targets** — `oci://` scheme detection + dispatch +
+   cache path + `handle_oci_template`, wiring into the existing render pipeline;
+   Rust integration tests against a local registry (Zot/`registry:2`).
+3. **Python `angreal.integrations.oci` binding** — pyclass/pymodule for
+   pull/push/tags/login, module registration, Python functional tests.
+4. **Documentation** — how-to (consume + publish an OCI template), integration
+   reference for `angreal.integrations.oci`, and a note on the artifact
+   convention. Update docs nav.
+
+## Open Questions / Risks
+- **musl + TLS**: CI builds musl wheels. Reuse the existing vendored-OpenSSL
+  native-tls backend for `oci-client` (its default) rather than adding rustls —
+  one TLS stack, already proven on musl. Confirm the compile early.
+- **tokio footprint**: first async dep; keep it feature-minimal (`rt`,
+  `macros`) and confined to the oci module.
+- **Registry test harness**: integration tests need a throwaway registry.
+  Prefer spinning `ghcr.io/project-zot/zot` or `registry:2` in CI (Docker is
+  already available for the docker integration tests) with a skip-if-unavailable
+  guard for local runs.

--- a/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0027.md
+++ b/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0027.md
@@ -1,0 +1,107 @@
+---
+id: oci-rust-core
+level: task
+title: "OCI Rust core: oci-client wrapper (pull/push/tags/auth)"
+short_code: "ANG-T-0027"
+created_at: 2026-07-26T00:00:00.000000+00:00
+updated_at: 2026-07-26T00:00:00.000000+00:00
+parent: ANG-I-0010
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+initiative_id: ANG-I-0010
+---
+
+# OCI Rust core: oci-client wrapper (pull/push/tags/auth)
+
+## Parent Initiative
+
+[[ANG-I-0010]]
+
+## Objective **[REQUIRED]**
+
+Build the shared, synchronous OCI client core in
+`crates/angreal/src/integrations/oci/` on top of the `oci-client` crate. This is
+the foundation both the `init` OCI targets ([[ANG-T-0028]]) and the Python
+binding ([[ANG-T-0029]]) consume.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `oci-client = "0.17"` (default features / native-tls) and
+      `tokio = { version = "1", features = ["rt"] }` added to `Cargo.toml`;
+      workspace builds clean.
+- [ ] A synchronous `Oci` API (async contained behind a `block_on` on a
+      current-thread runtime) providing:
+  - [ ] `pull_artifact(reference, dest, auth) -> Result<PathBuf>` — pulls the
+        manifest, fetches the template layer(s), unpacks the gzipped tar into
+        `dest`.
+  - [ ] `push_artifact(reference, src_dir, auth) -> Result<()>` — tar+gzips
+        `src_dir`, assembles config + layer + manifest with the angreal template
+        media types, pushes them.
+  - [ ] `list_tags(repository, auth) -> Result<Vec<String>>`.
+- [ ] Auth resolution: `Anonymous`, `Basic(user, pass)`, and a Docker
+      `~/.docker/config.json` credential helper.
+- [ ] Template artifact convention v1 constants defined:
+      config `application/vnd.angreal.template.config.v1+json`,
+      layer `application/vnd.angreal.template.layer.v1.tar+gzip`.
+- [ ] Push→pull round-trip is byte-for-byte faithful for a sample template dir.
+- [ ] `cargo build`, `cargo clippy`, and `cargo test` (unit) clean.
+- [ ] musl compile confirmed to reuse the existing vendored OpenSSL — no rustls,
+      no second TLS backend added.
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+### Technical Approach
+- New module `crates/angreal/src/integrations/oci/mod.rs`, registered in
+  `crates/angreal/src/integrations/mod.rs` (add `pub mod oci;`).
+- Model the module shape on `integrations/git.rs` / `integrations/flox/mod.rs`
+  (a struct with a `GitOutput`/`ComposeOutput`-style result where useful,
+  `is_available`, and high-level methods).
+- Contain async: build a `tokio::runtime::Builder::new_current_thread()` runtime
+  once per op (or lazily) and `block_on` each `oci-client` future so all public
+  methods are synchronous — no async leaks into the rest of angreal.
+- Tar/gzip: reuse an existing dep if present; otherwise add `tar` + `flate2`.
+- Reference parsing via `oci_client::Reference`; auth via
+  `oci_client::secrets::RegistryAuth`.
+
+### Risk Considerations
+- **TLS**: use `oci-client` default (native-tls) so it shares the vendored
+  OpenSSL already in the tree; do NOT enable `rustls-tls`. Confirm musl build.
+- **extension-module feature**: verify tokio + oci-client coexist with the
+  `pyo3/extension-module` build path.
+- Keep the runtime lightweight (`rt` only, no `rt-multi-thread`) to bound the
+  async footprint.
+
+## Status Updates **[REQUIRED]**
+
+- **Core implemented.** `crates/angreal/src/integrations/oci/mod.rs` added and
+  registered in `integrations/mod.rs`. Synchronous `Oci` API
+  (`pull_artifact` / `push_artifact` / `list_tags`) over `oci-client` 0.17, async
+  contained behind a per-op current-thread tokio runtime (`run_async`). `OciAuth`
+  (Anonymous / Basic) + `docker_config_auth` credential helper. Template media
+  types defined. Localhost registries auto-use HTTP for tests.
+- **Deps** added to `Cargo.toml`: `oci-client` (default-features off, `native-tls`),
+  `tokio` (`rt`/`net`/`time`), `tar`, `flate2`, `base64`.
+- **TLS: single backend confirmed.** oci-client 0.17 defaults to `rustls-tls`
+  (verified — it pulled in rustls + aws-lc-rs on first build); switched to
+  `native-tls` so it shares the vendored OpenSSL already in the tree.
+  `cargo tree -i rustls` / `aws-lc-rs` → not present. One TLS stack.
+- **Build**: `cargo build --lib` clean. Full workspace builds; the Python suite
+  (`angreal test all`) passes 249/2 skip/1 xpass, which exercises the extension
+  module built with all new deps.
+- **Rust unit tests pass locally: 108 passed / 0 failed**, incl. all 6 OCI tests
+  (media-type stability, auth default, reference parse/strip, garbage reject,
+  is_available, pack/unpack round-trip). Run via `angreal test rust --unit-only`.
+- **Fixed the macOS Rust-test-runner blocker (root cause, not a workaround).**
+  Added `crates/angreal/build.rs` + `pyo3-build-config` build-dependency that
+  emits the Python rpath from pyo3's own resolved build config (handles the
+  `.framework/` case). This makes pyo3 `auto-initialize` test binaries load
+  libpython without any `DYLD_*`/hardcoded-`PYO3_PYTHON` hacks, local and CI.
+  Pattern taken from `../cloacina` (`crates/cloacina-build::configure`). This was
+  a pre-existing repo issue surfaced by (not caused by) the OCI work.

--- a/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0028.md
+++ b/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0028.md
@@ -1,0 +1,86 @@
+---
+id: init-oci-targets
+level: task
+title: "init OCI template targets: oci:// scheme + cache + render"
+short_code: "ANG-T-0028"
+created_at: 2026-07-26T00:00:00.000000+00:00
+updated_at: 2026-07-26T00:00:00.000000+00:00
+parent: ANG-I-0010
+blocked_by:
+  - ANG-T-0027
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+initiative_id: ANG-I-0010
+---
+
+# init OCI template targets: oci:// scheme + cache + render
+
+## Parent Initiative
+
+[[ANG-I-0010]]
+
+## Objective **[REQUIRED]**
+
+Let `angreal init oci://<registry>/<repo>:<tag>` pull a template artifact via the
+OCI core ([[ANG-T-0027]]), cache it under `~/.angrealrc/oci/`, and feed it into
+the existing render pipeline unchanged.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `get_scheme` (`init.rs:115`) recognizes an `oci://` reference and returns
+      `"oci"`, short-circuiting **before** git-url parsing (same pattern as the
+      existing Windows-path guard).
+- [ ] `init` dispatch (`init.rs:40`) gains an `"oci"` arm calling
+      `handle_oci_template(reference, &angreal_home)`.
+- [ ] `handle_oci_template` pulls into
+      `~/.angrealrc/oci/<registry>/<repo>/<tag>/` and returns that path; a
+      cached unpack is reused / refreshed on tag.
+- [ ] After resolution the existing `render_template` path runs unchanged and
+      `init.py` executes correctly.
+- [ ] Default (non-`oci://`) `init` behavior is byte-for-byte unchanged.
+- [ ] Rust integration test pulls a template from a local registry
+      (`registry:2` or Zot) and renders it; guarded to skip if no registry.
+- [ ] `cargo build` / `cargo clippy` clean.
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+### Technical Approach
+- `crates/angreal/src/init.rs`:
+  - `get_scheme`: `if u.starts_with("oci://") { return Ok("oci".into()); }`
+    before `GitUrl::parse`.
+  - Add `"oci"` arm in the `match template_type.as_str()` block.
+  - `handle_oci_template(reference, angreal_home) -> PathBuf`: compute cache
+    path from the parsed `Reference`, call `oci::Oci::pull_artifact`, return the
+    unpacked template dir.
+- Integration test in `crates/angreal/tests/integration/` — push a fixture
+  template (via the core's push) then `init` it; skip-if-unavailable guard like
+  other environment-gated tests.
+
+### Risk Considerations
+- Cache-path derivation must sanitize registry/repo/tag into safe path segments.
+- Ensure the pulled tree contains `angreal.toml` at the expected root so
+  `render_template`'s compliance check passes.
+
+## Status Updates **[REQUIRED]**
+
+- **Complete.** `get_scheme` short-circuits `oci://` → `"oci"` (before git URL
+  parsing); `init` dispatch has an `"oci"` arm; `handle_oci_template` pulls into
+  `~/.angrealrc/oci/<registry>/<repo>/<tag>/` (cleared + re-pulled each run to
+  honor moved tags), auth via `oci::resolve_auth` (Docker config creds → else
+  anonymous), then the existing render pipeline runs unchanged.
+- OCI core gained `cache_subpath` (registry/repo/tag, port/colon sanitized) and
+  `resolve_auth` helpers so reference parsing stays in one place.
+- **Unit tests**: `get_scheme` oci detection + git-https regression; cache_subpath
+  mapping / default-latest / port sanitization. Full lib suite 113 passed / 0.
+- **Integration tests** (`tests/integration/oci.rs`, gated on
+  `ANGREAL_OCI_TEST_REGISTRY`): push→pull byte-faithful round-trip, and full
+  `init("oci://...")` e2e. **Verified live** against `registry:2` on
+  localhost:5555 — both pass; init rendered from
+  `~/.angrealrc/oci/localhost_5555/angreal-test/init/v1` and ran init.py. 17
+  passed / 0 failed.

--- a/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0029.md
+++ b/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0029.md
@@ -1,0 +1,85 @@
+---
+id: oci-python-binding
+level: task
+title: "Python angreal.integrations.oci binding (pull/push/tags/login)"
+short_code: "ANG-T-0029"
+created_at: 2026-07-26T00:00:00.000000+00:00
+updated_at: 2026-07-26T00:00:00.000000+00:00
+parent: ANG-I-0010
+blocked_by:
+  - ANG-T-0027
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+initiative_id: ANG-I-0010
+---
+
+# Python angreal.integrations.oci binding (pull/push/tags/login)
+
+## Parent Initiative
+
+[[ANG-I-0010]]
+
+## Objective **[REQUIRED]**
+
+Expose the OCI core ([[ANG-T-0027]]) to task authors as
+`angreal.integrations.oci`, mirroring the existing git/venv/flox binding pattern,
+with a minimal surface: pull, push, tags, login.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `crates/angreal/src/python_bindings/integrations/oci.rs` defines a
+      `#[pyclass] Oci` and `#[pymodule] oci` wrapping the core.
+- [ ] Methods: `Oci.pull(reference, dest=None)`, `Oci.push(reference, path)`,
+      `Oci.tags(repository)`, `Oci.login(registry, username, password)`.
+- [ ] Registered in `python_bindings/integrations/mod.rs` and added to
+      `sys.modules` as `angreal.integrations.oci` (as git/venv/flox are at
+      `python_bindings/integrations/mod.rs:31`).
+- [ ] Errors surface as Python exceptions via the existing formatter path.
+- [ ] `from angreal.integrations.oci import Oci` works after build.
+- [ ] Python functional test in `py_tests/integrations/test_oci.py` covers a
+      round-trip against a local registry; skip-if-unavailable guard.
+- [ ] `cargo build` / `cargo clippy` clean; `angreal test python` green.
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+### Technical Approach
+- Follow `python_bindings/integrations/flox.rs` for pyclass shape and path/str
+  argument handling.
+- `login` stores/returns credentials for subsequent calls (session-scoped) or
+  writes through to the Docker config helper — keep it simple: hold auth on the
+  `Oci` instance and pass into core calls.
+- Wire the module exactly like the git/venv/flox trio in
+  `python_bindings/integrations/mod.rs` (submodule + `sys.modules` entry).
+
+### Risk Considerations
+- Keep the Python surface thin — all real work lives in the core so behavior
+  matches the `init` path.
+- Accept both `str` and `pathlib.Path` for `dest`/`path` (flox binding shows the
+  pattern).
+
+## Status Updates **[REQUIRED]**
+
+- **Complete.** `python_bindings/integrations/oci.rs` defines `#[pyclass] Oci`
+  (name "Oci") + `#[pymodule] oci`, registered in `integrations/mod.rs` as a
+  submodule and in `sys.modules` as `angreal.integrations.oci`.
+- Surface: `Oci.login(registry, username, password)` (session creds, take
+  precedence over Docker config for that registry), `Oci.pull(reference,
+  dest=None)` (dest defaults to a cwd dir named after the repo basename),
+  `Oci.push(reference, path)`, `Oci.tags(repository)`. `dest`/`path` accept str
+  or `pathlib.Path` (pyo3 `PathBuf` conversion). Errors surface as
+  `RuntimeError`.
+- Core gained `reference_registry` + `reference_basename` helpers so the binding
+  stays thin and reference parsing stays centralized.
+- Gotcha fixed: `use ...oci::{self}` collided with `#[pymodule] fn oci`; aliased
+  the core import as `core`.
+- **Tests** (`py_tests/integrations/test_oci.py`): import/surface, login,
+  invalid-reference-raises always run; live push→tags→pull round-trip and
+  default-dest gated on `ANGREAL_OCI_TEST_REGISTRY`. **Verified live** against
+  `registry:2` on localhost:5555 — all 6 pass. Full Python suite: 255 passed /
+  2 skipped / 1 xpassed.

--- a/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0030.md
+++ b/.metis/initiatives/ANG-I-0010/tasks/ANG-T-0030.md
@@ -1,0 +1,71 @@
+---
+id: oci-documentation
+level: task
+title: "Documentation: OCI templates + angreal.integrations.oci"
+short_code: "ANG-T-0030"
+created_at: 2026-07-26T00:00:00.000000+00:00
+updated_at: 2026-07-26T00:00:00.000000+00:00
+parent: ANG-I-0010
+blocked_by:
+  - ANG-T-0028
+  - ANG-T-0029
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+initiative_id: ANG-I-0010
+---
+
+# Documentation: OCI templates + angreal.integrations.oci
+
+## Parent Initiative
+
+[[ANG-I-0010]]
+
+## Objective **[REQUIRED]**
+
+Document both OCI capabilities: consuming/publishing OCI template targets, and
+the `angreal.integrations.oci` plugin surface, including the template artifact
+convention.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] How-to guide: consume a template with `angreal init oci://...` and publish
+      one (push), with a concrete GHCR/registry example.
+- [ ] Integration reference for `angreal.integrations.oci`
+      (pull/push/tags/login) alongside the existing git/venv/flox references.
+- [ ] Documented template artifact convention v1 (config + layer media types).
+- [ ] MkDocs nav updated; `angreal docs build` (strict) passes.
+- [ ] Examples verified against the implementation (accuracy pass).
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+### Technical Approach
+- Follow the structure/style of the Flox integration docs (see [[ANG-T-0017]] /
+  [[ANG-T-0018]]).
+- Place how-to under the docs tree next to other init/template guides; place the
+  integration reference next to other `angreal.integrations.*` pages.
+- Build with the `angreal docs build` task (strict) to match CI.
+
+### Risk Considerations
+- Keep registry examples provider-neutral where possible; note auth differences
+  (anonymous vs basic vs docker config).
+
+## Status Updates **[REQUIRED]**
+
+- **Complete.** Authored:
+  - How-to `docs/how-to-guides/use-oci-templates.md` — consume (`init oci://…`,
+    private registries, in-place) and publish (push via `Oci`), plus a
+    local-registry try-it loop.
+  - Reference `docs/reference/python-api/integrations/oci.md` — `Oci`
+    pull/push/tags/login, auth resolution order, and the v1 artifact media-type
+    convention.
+- Updated: integrations reference index (added OCI entry); `angreal init`
+  behavior explanation (added the `oci://` branch to the decision tree + prose);
+  `mkdocs.yml` nav (how-to, hand-written reference, and the Plissken-generated
+  Python + Rust `oci` API pages, for parity with the other integrations).
+- **Verified**: `angreal docs build` (strict) exits 0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,8 +31,10 @@ name = "angreal"
 version = "2.8.8"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "docker-pyo3",
+ "flate2",
  "git-url-parse",
  "git2",
  "git2_credentials",
@@ -40,19 +42,23 @@ dependencies = [
  "home",
  "log",
  "log4rs",
+ "oci-client",
  "once_cell",
  "openssl",
  "pyo3",
+ "pyo3-build-config",
  "pythonize",
  "rand 0.8.5",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "same-file",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "tera",
  "text_io",
+ "tokio",
  "toml",
  "version",
  "version-compare",
@@ -88,6 +94,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +133,18 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -135,6 +165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -257,6 +296,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "containers-api"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,8 +337,8 @@ dependencies = [
  "chrono",
  "flate2",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.32",
  "hyperlocal",
  "log",
  "mime",
@@ -316,6 +388,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +431,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +450,42 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -395,6 +524,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +542,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -456,8 +627,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -505,8 +689,8 @@ dependencies = [
  "containers-api",
  "docker-api-stubs",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.32",
  "log",
  "paste",
  "serde",
@@ -548,6 +732,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +826,22 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -700,6 +959,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -714,6 +974,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -750,6 +1011,17 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -823,6 +1095,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,7 +1116,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -884,6 +1167,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,13 +1205,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -942,6 +1285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,8 +1304,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -966,16 +1318,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -986,7 +1397,7 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.32",
  "pin-project",
  "tokio",
 ]
@@ -1210,10 +1621,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1425,10 +1876,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1437,6 +1923,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "hex",
+ "http 1.4.2",
+ "http-auth",
+ "jsonwebtoken",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1521,6 +2063,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +2123,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1604,7 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1672,6 +2247,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +2317,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1954,10 +2559,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -1970,7 +2575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -1980,6 +2585,75 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2011,6 +2685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -2048,6 +2731,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2200,8 +2897,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2215,6 +2923,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2271,6 +2989,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +3044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +3065,15 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2523,6 +3272,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +3371,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,8 +3421,21 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2648,9 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -2659,10 +3475,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2867,6 +3698,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3321,6 +4165,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/angreal/Cargo.toml
+++ b/crates/angreal/Cargo.toml
@@ -20,16 +20,21 @@ path = "tests/integration/lib.rs"
 
 [dependencies]
 anyhow = {version = "1.0.72"}
+base64 = { version = "0.22" }
 clap = { version = "3" }
 docker-pyo3 = { version = "0.3.2" }
 git-url-parse = { version = "0.4.4" }
 git2 = { version = "0.16"}
 git2_credentials = { version = "0.11.0"}
+flate2 = { version = "1" }
 glob = { version = "0.3.0" }
 home = { version = "0.5.4" }
 log = { version = "0.4" }
 regex = { version = "1.8" }
 log4rs = { version ="1.2.0"}
+# default features pull in rustls + aws-lc-rs; disable them and use native-tls
+# so oci-client shares the vendored OpenSSL already in this tree (one TLS backend).
+oci-client = { version = "0.17", default-features = false, features = ["native-tls"] }
 once_cell = { version = "1.3.1"}
 openssl = { version = "0.10", features = ["vendored"] }
 pythonize = { version ="0.27" }
@@ -37,13 +42,20 @@ pyo3 = { version = "0.27", features = ["auto-initialize"]}
 reqwest = { version = "0.11.18", features = ["blocking","json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1" }
+tar = { version = "0.4" }
 tempfile = { version = "3.10.0"}
 tera = { version = "1.17.1" , features = ["builtins"]}
 text_io = { version = "0.1.12" }
+tokio = { version = "1", features = ["rt", "net", "time"] }
 toml = { version = "0.6", features=["preserve_order"] }
 version = { version = "3.0.0" }
 version-compare = { version = "0.1.1" }
 walkdir = { version = "2.3.2" }
+
+[build-dependencies]
+# Emits the Python rpath so pyo3 `auto-initialize` test binaries load libpython
+# at runtime (esp. macOS framework builds). See build.rs.
+pyo3-build-config = { version = "0.27" }
 
 [features]
 extension-module = ["pyo3/extension-module", "docker-pyo3/extension-module"]

--- a/crates/angreal/build.rs
+++ b/crates/angreal/build.rs
@@ -1,0 +1,38 @@
+//! Build script for angreal.
+//!
+//! angreal embeds Python via PyO3 (`auto-initialize`). Any binary that links it
+//! — notably the `cargo test` unit/integration harnesses — must find the Python
+//! shared library at runtime. On macOS framework builds the dylib is loaded as
+//! `@rpath/Python3.framework/Versions/3.x/Python3`, so without an rpath those
+//! test binaries crash at launch with:
+//!
+//! ```text
+//! dyld: Library not loaded: @rpath/Python3.framework/Versions/3.x/Python3
+//! ```
+//!
+//! We emit the rpath from PyO3's own resolved build config, so it always matches
+//! whichever interpreter PyO3 linked against — no hardcoded paths, no PATH or
+//! DYLD_* workarounds. (The extension-module build uses dynamic lookup and does
+//! not embed libpython, so the extra rpath there is a harmless no-op.)
+
+fn main() {
+    pyo3_build_config::use_pyo3_cfgs();
+
+    let config = pyo3_build_config::get();
+    if let Some(lib_dir) = &config.lib_dir {
+        // Framework builds load the dylib as @rpath/Python3.framework/..., so the
+        // rpath must point at the directory *containing* the framework, not the
+        // inner lib dir.
+        let rpath = if lib_dir.contains(".framework/") {
+            let parts: Vec<&str> = lib_dir.splitn(2, ".framework/").collect();
+            std::path::Path::new(parts[0])
+                .parent()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| lib_dir.clone())
+        } else {
+            lib_dir.clone()
+        };
+
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{rpath}");
+    }
+}

--- a/crates/angreal/src/init.rs
+++ b/crates/angreal/src/init.rs
@@ -44,6 +44,7 @@ pub fn init(
             handle_git_template(template, angreal_home)
         }
         "file" => PathBuf::from(handle_file_template(template, &angreal_home)),
+        "oci" => handle_oci_template(template, &angreal_home),
         &_ => {
             error!(
                 "Unhandled template type {} from {}, exiting.",
@@ -120,6 +121,12 @@ fn get_scheme(u: &str) -> Result<String, String> {
     // without going through URL parsing at all.
     if Path::new(u).is_dir() {
         return Ok("file".to_string());
+    }
+
+    // OCI references carry an explicit `oci://` scheme. Short-circuit before git
+    // URL parsing, which does not understand it.
+    if u.starts_with("oci://") {
+        return Ok("oci".to_string());
     }
 
     let s = GitUrl::parse(u).map_err(|_| format!("Failed to parse URL: {u}"))?;
@@ -248,6 +255,43 @@ fn handle_git_template(template: &str, angreal_home: PathBuf) -> PathBuf {
     dst
 }
 
+/// Pull an OCI template artifact into the local cache and return the unpacked
+/// template directory, ready for rendering.
+///
+/// The cache lives at `~/.angrealrc/oci/<registry>/<repository>/<tag>/`. As with
+/// git templates (which ff-pull), the artifact is re-fetched each run so a moved
+/// tag is honored; the cache dir is cleared first to avoid mixing in stale files
+/// from a previous pull of the same tag.
+fn handle_oci_template(template: &str, angreal_home: &Path) -> PathBuf {
+    use crate::integrations::oci;
+
+    let subpath = match oci::cache_subpath(template) {
+        Ok(p) => p,
+        Err(e) => {
+            error!("{}", e);
+            exit(1);
+        }
+    };
+    let dst = angreal_home.join("oci").join(subpath);
+
+    if dst.exists() {
+        debug!("OCI template cache exists at {:?}, refreshing.", dst);
+        if let Err(e) = fs::remove_dir_all(&dst) {
+            error!("Failed to clear OCI template cache at {:?}: {}", dst, e);
+            exit(1);
+        }
+    }
+
+    debug!("Pulling OCI template {} into {:?}", template, dst);
+    match oci::Oci::pull_artifact(template, &dst, &oci::resolve_auth(template)) {
+        Ok(path) => path,
+        Err(e) => {
+            error!("Failed to pull OCI template {}: {}", template, e);
+            exit(1);
+        }
+    }
+}
+
 /// create the angreal caching directory for storing cloned templates
 pub fn create_home_dot_angreal() -> PathBuf {
     let mut home_dir = home_dir().unwrap();
@@ -314,4 +358,26 @@ pub fn render_template(
     // angreal_path
     String::new()
     // return path to .angreal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_scheme;
+
+    #[test]
+    fn get_scheme_detects_oci() {
+        assert_eq!(
+            get_scheme("oci://ghcr.io/angreal/python:latest").unwrap(),
+            "oci"
+        );
+        assert_eq!(get_scheme("oci://localhost:5000/demo:v1").unwrap(), "oci");
+    }
+
+    #[test]
+    fn get_scheme_still_detects_git_https() {
+        assert_eq!(
+            get_scheme("https://github.com/angreal/angreal.git").unwrap(),
+            "https"
+        );
+    }
 }

--- a/crates/angreal/src/integrations/mod.rs
+++ b/crates/angreal/src/integrations/mod.rs
@@ -1,4 +1,5 @@
 pub mod docker_compose;
 pub mod flox;
 pub mod git;
+pub mod oci;
 pub mod uv;

--- a/crates/angreal/src/integrations/oci/mod.rs
+++ b/crates/angreal/src/integrations/oci/mod.rs
@@ -1,0 +1,386 @@
+//! OCI registry integration.
+//!
+//! A synchronous wrapper over the async [`oci_client`] crate. Every public
+//! method blocks on a small current-thread tokio runtime so the rest of angreal
+//! — which is entirely synchronous — can pull and push OCI artifacts without
+//! ever touching `async`. This module is the shared core consumed both by
+//! `angreal init oci://...` (template targets) and by the
+//! `angreal.integrations.oci` Python binding.
+//!
+//! ## Template artifact convention (v1)
+//!
+//! An angreal template is distributed as a standard OCI image manifest with:
+//! - a config blob of media type [`ANGREAL_CONFIG_MEDIA_TYPE`], and
+//! - one layer of media type [`ANGREAL_LAYER_MEDIA_TYPE`] — a gzipped tar of the
+//!   template directory (the same tree `angreal init` renders).
+//!
+//! Because it is a spec-compliant manifest, `oras`/`skopeo` and any OCI registry
+//! interoperate with artifacts angreal pushes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use oci_client::client::{ClientConfig, ClientProtocol, Config, ImageLayer};
+use oci_client::secrets::RegistryAuth;
+use oci_client::{Client, Reference};
+use tar::Archive;
+
+/// Media type for the angreal template artifact config blob.
+pub const ANGREAL_CONFIG_MEDIA_TYPE: &str = "application/vnd.angreal.template.config.v1+json";
+
+/// Media type for the angreal template artifact layer: a gzipped tar of the
+/// template directory.
+pub const ANGREAL_LAYER_MEDIA_TYPE: &str = "application/vnd.angreal.template.layer.v1.tar+gzip";
+
+/// Authentication for a registry operation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum OciAuth {
+    /// No credentials — for public, read-anonymous repositories.
+    #[default]
+    Anonymous,
+    /// HTTP Basic credentials (username + password or token).
+    Basic { username: String, password: String },
+}
+
+impl OciAuth {
+    fn to_registry_auth(&self) -> RegistryAuth {
+        match self {
+            OciAuth::Anonymous => RegistryAuth::Anonymous,
+            OciAuth::Basic { username, password } => {
+                RegistryAuth::Basic(username.clone(), password.clone())
+            }
+        }
+    }
+}
+
+/// Synchronous OCI registry client for angreal template artifacts.
+pub struct Oci;
+
+impl Oci {
+    /// Whether OCI support is available. Always `true` — the client is bundled
+    /// (pure Rust), with no external binary or daemon required.
+    pub fn is_available() -> bool {
+        true
+    }
+
+    /// Pull a template artifact and unpack its layer into `dest`.
+    ///
+    /// Accepts a bare reference (`registry/repo:tag`) or one with an `oci://`
+    /// scheme prefix. Returns the destination path on success.
+    pub fn pull_artifact(reference: &str, dest: &Path, auth: &OciAuth) -> Result<PathBuf> {
+        let reference = parse_reference(reference)?;
+        let client = build_client(&reference);
+        let registry_auth = auth.to_registry_auth();
+
+        let image_data = run_async(async {
+            client
+                .pull(&reference, &registry_auth, vec![ANGREAL_LAYER_MEDIA_TYPE])
+                .await
+        })
+        .map_err(|e| anyhow!("failed to pull OCI artifact '{reference}': {e}"))?;
+
+        fs::create_dir_all(dest)
+            .with_context(|| format!("failed to create destination '{}'", dest.display()))?;
+
+        let mut unpacked = false;
+        for layer in &image_data.layers {
+            if layer.media_type == ANGREAL_LAYER_MEDIA_TYPE {
+                unpack_targz(&layer.data, dest).with_context(|| {
+                    format!("failed to unpack template layer into '{}'", dest.display())
+                })?;
+                unpacked = true;
+            }
+        }
+
+        if !unpacked {
+            bail!(
+                "OCI artifact '{reference}' contains no angreal template layer \
+                 (expected media type '{ANGREAL_LAYER_MEDIA_TYPE}')"
+            );
+        }
+
+        Ok(dest.to_path_buf())
+    }
+
+    /// Package `src_dir` as an angreal template artifact and push it to
+    /// `reference`.
+    pub fn push_artifact(reference: &str, src_dir: &Path, auth: &OciAuth) -> Result<()> {
+        if !src_dir.is_dir() {
+            bail!(
+                "cannot push OCI template: '{}' is not a directory",
+                src_dir.display()
+            );
+        }
+
+        let reference = parse_reference(reference)?;
+        let client = build_client(&reference);
+        let registry_auth = auth.to_registry_auth();
+
+        let tar_gz = pack_targz(src_dir).with_context(|| {
+            format!(
+                "failed to package template directory '{}'",
+                src_dir.display()
+            )
+        })?;
+
+        let layer = ImageLayer::new(tar_gz, ANGREAL_LAYER_MEDIA_TYPE.to_string(), None);
+        let config = Config::new(
+            template_config_blob(),
+            ANGREAL_CONFIG_MEDIA_TYPE.to_string(),
+            None,
+        );
+
+        run_async(async {
+            client
+                .push(&reference, &[layer], config, &registry_auth, None)
+                .await
+        })
+        .map_err(|e| anyhow!("failed to push OCI artifact '{reference}': {e}"))?;
+
+        Ok(())
+    }
+
+    /// List the tags available for a repository.
+    pub fn list_tags(repository: &str, auth: &OciAuth) -> Result<Vec<String>> {
+        let reference = parse_reference(repository)?;
+        let client = build_client(&reference);
+        let registry_auth = auth.to_registry_auth();
+
+        let response = run_async(async {
+            client
+                .list_tags(&reference, &registry_auth, None, None)
+                .await
+        })
+        .map_err(|e| anyhow!("failed to list tags for '{reference}': {e}"))?;
+
+        Ok(response.tags)
+    }
+}
+
+/// Resolve Basic auth for `registry` from the Docker `~/.docker/config.json`
+/// credential store, if present. Returns `None` when no matching entry exists.
+pub fn docker_config_auth(registry: &str) -> Option<OciAuth> {
+    let config_path = home::home_dir()?.join(".docker").join("config.json");
+    let contents = fs::read_to_string(config_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let auths = json.get("auths")?.as_object()?;
+
+    // Registries appear under several conventional key spellings.
+    let entry = auths
+        .get(registry)
+        .or_else(|| auths.get(&format!("https://{registry}")))
+        .or_else(|| auths.get(&format!("https://{registry}/v1/")))?;
+
+    let encoded = entry.get("auth")?.as_str()?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    let pair = String::from_utf8(decoded).ok()?;
+    let (username, password) = pair.split_once(':')?;
+
+    Some(OciAuth::Basic {
+        username: username.to_string(),
+        password: password.to_string(),
+    })
+}
+
+/// Resolve auth for a reference: Docker `config.json` credentials for the
+/// registry if present, otherwise anonymous. Shared by `angreal init oci://...`
+/// and the Python binding so both authenticate the same way.
+pub fn resolve_auth(reference: &str) -> OciAuth {
+    parse_reference(reference)
+        .ok()
+        .and_then(|r| docker_config_auth(r.registry()))
+        .unwrap_or(OciAuth::Anonymous)
+}
+
+/// The registry host (and port) of a reference, e.g. `ghcr.io` or
+/// `localhost:5000`.
+pub fn reference_registry(reference: &str) -> Result<String> {
+    Ok(parse_reference(reference)?.registry().to_string())
+}
+
+/// The conventional local directory name for a reference — its repository's last
+/// path segment — used as the default pull destination.
+pub fn reference_basename(reference: &str) -> Result<String> {
+    let r = parse_reference(reference)?;
+    let name = r.repository().rsplit('/').next().unwrap_or("template");
+    Ok(sanitize_segment(name))
+}
+
+/// Compute a filesystem-safe cache subpath (`<registry>/<repository>/<version>`)
+/// for a reference, used to key the local template cache. `version` is the tag,
+/// else the digest, else `latest`.
+pub fn cache_subpath(reference: &str) -> Result<PathBuf> {
+    let r = parse_reference(reference)?;
+    let version = r.tag().or_else(|| r.digest()).unwrap_or("latest");
+
+    let mut path = PathBuf::from(sanitize_segment(r.registry()));
+    for segment in r.repository().split('/') {
+        path.push(sanitize_segment(segment));
+    }
+    path.push(sanitize_segment(version));
+    Ok(path)
+}
+
+/// Reduce a reference component to a safe single path segment (registries carry
+/// ports/colons, digests carry colons — neither is portable in a path).
+fn sanitize_segment(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Parse a reference, tolerating an optional `oci://` scheme prefix.
+fn parse_reference(reference: &str) -> Result<Reference> {
+    let stripped = reference.strip_prefix("oci://").unwrap_or(reference);
+    stripped
+        .parse::<Reference>()
+        .map_err(|e| anyhow!("invalid OCI reference '{reference}': {e}"))
+}
+
+/// Build a client for the given reference. Registries on `localhost` /
+/// `127.0.0.1` are contacted over plain HTTP (test registries); everything else
+/// uses HTTPS, riding the vendored-OpenSSL native-tls backend already in the
+/// tree.
+fn build_client(reference: &Reference) -> Client {
+    let registry = reference.registry();
+    let protocol = if registry.starts_with("localhost") || registry.starts_with("127.0.0.1") {
+        ClientProtocol::HttpsExcept(vec![registry.to_string()])
+    } else {
+        ClientProtocol::Https
+    };
+
+    Client::new(ClientConfig {
+        protocol,
+        ..Default::default()
+    })
+}
+
+/// Block on `fut` using a lightweight current-thread runtime. The async surface
+/// of `oci-client` is fully contained here.
+fn run_async<F: std::future::Future>(fut: F) -> F::Output {
+    // A fresh current-thread runtime per operation keeps the async footprint
+    // minimal and avoids holding a runtime across the synchronous API boundary.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime for OCI operation");
+    runtime.block_on(fut)
+}
+
+/// The config blob embedded in a pushed template artifact.
+fn template_config_blob() -> Vec<u8> {
+    let config = serde_json::json!({
+        "angrealVersion": env!("CARGO_PKG_VERSION"),
+        "artifactType": "application/vnd.angreal.template",
+    });
+    serde_json::to_vec(&config).unwrap_or_else(|_| b"{}".to_vec())
+}
+
+/// gzip+tar the contents of `src_dir` (rooted at `.`) into an in-memory buffer.
+fn pack_targz(src_dir: &Path) -> Result<Vec<u8>> {
+    let encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let mut builder = tar::Builder::new(encoder);
+    builder.append_dir_all(".", src_dir)?;
+    let encoder = builder.into_inner()?;
+    let bytes = encoder.finish()?;
+    Ok(bytes)
+}
+
+/// Unpack a gzipped tar buffer into `dest`.
+fn unpack_targz(data: &[u8], dest: &Path) -> Result<()> {
+    let decoder = GzDecoder::new(data);
+    let mut archive = Archive::new(decoder);
+    archive.unpack(dest)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn media_types_are_stable() {
+        assert_eq!(
+            ANGREAL_CONFIG_MEDIA_TYPE,
+            "application/vnd.angreal.template.config.v1+json"
+        );
+        assert_eq!(
+            ANGREAL_LAYER_MEDIA_TYPE,
+            "application/vnd.angreal.template.layer.v1.tar+gzip"
+        );
+    }
+
+    #[test]
+    fn oci_auth_defaults_to_anonymous() {
+        assert_eq!(OciAuth::default(), OciAuth::Anonymous);
+    }
+
+    #[test]
+    fn parse_reference_strips_oci_scheme() {
+        let a = parse_reference("oci://ghcr.io/angreal/python:latest").unwrap();
+        let b = parse_reference("ghcr.io/angreal/python:latest").unwrap();
+        assert_eq!(a.registry(), "ghcr.io");
+        assert_eq!(a.repository(), b.repository());
+        assert_eq!(a.tag(), Some("latest"));
+    }
+
+    #[test]
+    fn parse_reference_rejects_garbage() {
+        assert!(parse_reference("not a reference !!").is_err());
+    }
+
+    #[test]
+    fn is_available_is_true() {
+        assert!(Oci::is_available());
+    }
+
+    #[test]
+    fn cache_subpath_maps_registry_repo_tag() {
+        let p = cache_subpath("oci://ghcr.io/angreal/python:latest").unwrap();
+        assert_eq!(p, PathBuf::from("ghcr.io/angreal/python/latest"));
+    }
+
+    #[test]
+    fn cache_subpath_defaults_tag_to_latest() {
+        let p = cache_subpath("ghcr.io/angreal/python").unwrap();
+        assert_eq!(p, PathBuf::from("ghcr.io/angreal/python/latest"));
+    }
+
+    #[test]
+    fn cache_subpath_sanitizes_registry_port() {
+        let p = cache_subpath("localhost:5000/demo:v1").unwrap();
+        assert_eq!(p, PathBuf::from("localhost_5000/demo/v1"));
+    }
+
+    #[test]
+    fn pack_unpack_roundtrip_is_faithful() {
+        let src = TempDir::new().unwrap();
+        fs::write(src.path().join("angreal.toml"), "name = \"demo\"\n").unwrap();
+        fs::create_dir(src.path().join("sub")).unwrap();
+        fs::write(src.path().join("sub").join("file.txt"), "hello\n").unwrap();
+
+        let packed = pack_targz(src.path()).unwrap();
+
+        let dest = TempDir::new().unwrap();
+        unpack_targz(&packed, dest.path()).unwrap();
+
+        let toml = fs::read_to_string(dest.path().join("angreal.toml")).unwrap();
+        assert_eq!(toml, "name = \"demo\"\n");
+        let nested = fs::read_to_string(dest.path().join("sub").join("file.txt")).unwrap();
+        assert_eq!(nested, "hello\n");
+    }
+}

--- a/crates/angreal/src/python_bindings/integrations/mod.rs
+++ b/crates/angreal/src/python_bindings/integrations/mod.rs
@@ -7,6 +7,7 @@ pub mod compose;
 pub mod docker;
 pub mod flox;
 pub mod git;
+pub mod oci;
 pub mod venv;
 
 /// Create the integrations submodule
@@ -28,12 +29,17 @@ pub fn integrations(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     let flox_module = wrap_pymodule!(flox::flox)(py);
     m.add_submodule(flox_module.bind(py))?;
 
+    // Create and register the oci submodule
+    let oci_module = wrap_pymodule!(oci::oci)(py);
+    m.add_submodule(oci_module.bind(py))?;
+
     // Also register all modules in sys.modules for proper import support
     let sys = py.import("sys")?;
     let modules = sys.getattr("modules")?;
     modules.set_item("angreal.integrations.git", git_module)?;
     modules.set_item("angreal.integrations.venv", venv_module)?;
     modules.set_item("angreal.integrations.flox", flox_module)?;
+    modules.set_item("angreal.integrations.oci", oci_module)?;
 
     Ok(())
 }

--- a/crates/angreal/src/python_bindings/integrations/oci.rs
+++ b/crates/angreal/src/python_bindings/integrations/oci.rs
@@ -1,0 +1,106 @@
+//! OCI registry integration bindings.
+//!
+//! Exposes a minimal `angreal.integrations.oci.Oci` surface — pull, push, tags,
+//! login — over the shared OCI core (`crate::integrations::oci`). All heavy
+//! lifting (registry I/O, auth, the template artifact convention) lives in the
+//! core so this binding stays a thin adapter and matches the `init oci://…` path.
+
+#![allow(non_local_definitions)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use pyo3::prelude::*;
+
+use crate::integrations::oci::{self as core, Oci, OciAuth};
+
+fn to_pyerr(e: anyhow::Error) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
+}
+
+/// OCI registry client for angreal template artifacts.
+///
+/// Pull and push templates, list tags, and authenticate against registries.
+/// Credentials set via `login()` are held for the lifetime of the instance and
+/// take precedence over Docker `config.json` credentials for that registry.
+#[pyclass(name = "Oci")]
+pub struct PyOci {
+    /// Per-registry credentials registered via `login()`.
+    credentials: Mutex<HashMap<String, OciAuth>>,
+}
+
+impl PyOci {
+    /// Resolve auth for a reference: a `login()` credential for its registry if
+    /// present, otherwise the core default (Docker config → anonymous).
+    fn auth_for(&self, reference: &str) -> OciAuth {
+        if let Ok(registry) = core::reference_registry(reference) {
+            if let Some(auth) = self
+                .credentials
+                .lock()
+                .expect("oci credentials mutex poisoned")
+                .get(&registry)
+                .cloned()
+            {
+                return auth;
+            }
+        }
+        core::resolve_auth(reference)
+    }
+}
+
+#[pymethods]
+impl PyOci {
+    #[new]
+    fn new() -> Self {
+        Self {
+            credentials: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Store Basic credentials for `registry` (e.g. `ghcr.io`), used by
+    /// subsequent pull/push/tags calls against that registry.
+    fn login(&self, registry: &str, username: String, password: String) -> PyResult<()> {
+        self.credentials
+            .lock()
+            .expect("oci credentials mutex poisoned")
+            .insert(registry.to_string(), OciAuth::Basic { username, password });
+        Ok(())
+    }
+
+    /// Pull a template artifact to `dest` (default: a directory named after the
+    /// repository, under the current directory). Returns the destination path.
+    #[pyo3(signature = (reference, dest=None))]
+    fn pull(&self, reference: &str, dest: Option<PathBuf>) -> PyResult<String> {
+        let dest = match dest {
+            Some(d) => d,
+            None => {
+                let name = core::reference_basename(reference).map_err(to_pyerr)?;
+                std::env::current_dir()?.join(name)
+            }
+        };
+        let auth = self.auth_for(reference);
+        let out = Oci::pull_artifact(reference, &dest, &auth).map_err(to_pyerr)?;
+        Ok(out.display().to_string())
+    }
+
+    /// Package the directory at `path` as a template artifact and push it to
+    /// `reference`.
+    fn push(&self, reference: &str, path: PathBuf) -> PyResult<()> {
+        let auth = self.auth_for(reference);
+        Oci::push_artifact(reference, &path, &auth).map_err(to_pyerr)
+    }
+
+    /// List the tags available for `repository`.
+    fn tags(&self, repository: &str) -> PyResult<Vec<String>> {
+        let auth = self.auth_for(repository);
+        Oci::list_tags(repository, &auth).map_err(to_pyerr)
+    }
+}
+
+/// OCI integration module, exposed as `angreal.integrations.oci` in Python.
+#[pymodule]
+pub fn oci(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyOci>()?;
+    Ok(())
+}

--- a/crates/angreal/tests/integration/lib.rs
+++ b/crates/angreal/tests/integration/lib.rs
@@ -1,2 +1,3 @@
 pub mod git;
 pub mod init;
+pub mod oci;

--- a/crates/angreal/tests/integration/oci.rs
+++ b/crates/angreal/tests/integration/oci.rs
@@ -1,0 +1,131 @@
+//! OCI template target integration tests.
+//!
+//! These exercise the real registry round-trip: package a fixture template, push
+//! it as an OCI artifact, then pull/render it back. They require a running OCI
+//! registry and are skipped unless `ANGREAL_OCI_TEST_REGISTRY` names one
+//! (e.g. `localhost:5000`). Spin one up with:
+//!
+//! ```text
+//! docker run -d --rm -p 5000:5000 registry:2
+//! ANGREAL_OCI_TEST_REGISTRY=localhost:5000 angreal test rust --integration-only
+//! ```
+
+use angreal::init::{create_home_dot_angreal, init};
+use angreal::integrations::oci::{self, Oci, OciAuth};
+use std::env;
+use std::fs;
+use std::ops::Not;
+use std::path::{Path, PathBuf};
+
+/// Registry to test against, or `None` to skip.
+fn test_registry() -> Option<String> {
+    match env::var("ANGREAL_OCI_TEST_REGISTRY") {
+        Ok(v) if !v.trim().is_empty() => Some(v),
+        _ => {
+            eprintln!(
+                "skipping OCI integration test: set ANGREAL_OCI_TEST_REGISTRY \
+                 (e.g. localhost:5000) to run"
+            );
+            None
+        }
+    }
+}
+
+/// Build a minimal but valid angreal template at `root`:
+///
+/// ```text
+/// <root>/
+///   angreal.toml
+///   {{ folder_variable }}/
+///     README.rst
+///     .angreal/init.py
+/// ```
+fn make_template(root: &Path) -> PathBuf {
+    let template = root.join("template");
+    let inner = template.join("{{ folder_variable }}");
+    fs::create_dir_all(inner.join(".angreal")).unwrap();
+
+    fs::write(
+        template.join("angreal.toml"),
+        "folder_variable = \"oci_rendered\"\n",
+    )
+    .unwrap();
+    fs::write(inner.join("README.rst"), "# {{ folder_variable }}\n").unwrap();
+    fs::write(
+        inner.join(".angreal").join("init.py"),
+        "def init():\n    pass\n",
+    )
+    .unwrap();
+
+    template
+}
+
+/// push → pull round-trip through the core is byte-faithful.
+#[test]
+fn test_oci_push_pull_roundtrip() {
+    let Some(registry) = test_registry() else {
+        return;
+    };
+
+    let tmp = env::temp_dir().join(format!("angreal_oci_rt_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp);
+    let template = make_template(&tmp);
+
+    let reference = format!("oci://{registry}/angreal-test/roundtrip:v1");
+    Oci::push_artifact(&reference, &template, &OciAuth::Anonymous)
+        .expect("push should succeed against the test registry");
+
+    let dest = tmp.join("pulled");
+    let out = Oci::pull_artifact(&reference, &dest, &oci::resolve_auth(&reference))
+        .expect("pull should succeed");
+
+    assert_eq!(out, dest);
+    let toml = fs::read_to_string(dest.join("angreal.toml")).unwrap();
+    assert!(toml.contains("folder_variable"));
+    assert!(dest
+        .join("{{ folder_variable }}")
+        .join("README.rst")
+        .is_file());
+
+    let _ = fs::remove_dir_all(&tmp);
+}
+
+/// Full `angreal init oci://...` renders the pushed template into cwd.
+#[test]
+fn test_init_from_oci() {
+    let Some(registry) = test_registry() else {
+        return;
+    };
+
+    let tmp = env::temp_dir().join(format!("angreal_oci_init_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp);
+    let template = make_template(&tmp);
+
+    let reference = format!("oci://{registry}/angreal-test/init:v1");
+    Oci::push_artifact(&reference, &template, &OciAuth::Anonymous)
+        .expect("push should succeed against the test registry");
+
+    // init() renders relative to the process cwd; render into an isolated temp.
+    let cwd = tmp.join("dest");
+    fs::create_dir_all(&cwd).unwrap();
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(&cwd).unwrap();
+
+    init(&reference, true, false, None, false);
+
+    env::set_current_dir(&original).unwrap();
+
+    let rendered_root = cwd.join("oci_rendered");
+    let rendered_exists = rendered_root.is_dir();
+    let readme_exists = rendered_root.join("README.rst").is_file();
+    let dot_angreal_exists = rendered_root.join(".angreal").is_dir();
+    let unrendered_root_absent = cwd.join("{{ folder_variable }}").exists().not();
+
+    let _ = fs::remove_dir_all(&tmp);
+    let _ = fs::remove_dir_all(create_home_dot_angreal());
+
+    assert!(rendered_exists, "expected rendered root {rendered_root:?}");
+    assert!(readme_exists);
+    assert!(dot_angreal_exists);
+    assert!(unrendered_root_absent);
+}

--- a/crates/angreal/tests/integration/oci.rs
+++ b/crates/angreal/tests/integration/oci.rs
@@ -60,6 +60,32 @@ fn make_template(root: &Path) -> PathBuf {
     template
 }
 
+/// HTTPS smoke test against a public registry.
+///
+/// The localhost round-trip tests talk plain HTTP, so they never exercise TLS.
+/// Real use (`angreal init oci://ghcr.io/...`) is HTTPS, and on macOS the
+/// native-tls backend resolves to Apple's SecureTransport — a different code
+/// path from Linux's OpenSSL. This proves that path reaches a real registry
+/// (DNS + TLS + the anonymous bearer-token dance + the tags API).
+///
+/// Opt-in via `ANGREAL_OCI_HTTPS_SMOKE=1` (needs network + Docker Hub) so it
+/// never runs in the default/offline suite.
+#[test]
+fn test_https_public_registry_smoke() {
+    if env::var("ANGREAL_OCI_HTTPS_SMOKE").ok().as_deref() != Some("1") {
+        eprintln!("skipping HTTPS smoke: set ANGREAL_OCI_HTTPS_SMOKE=1 to run");
+        return;
+    }
+
+    let tags = Oci::list_tags("docker.io/library/hello-world", &OciAuth::Anonymous)
+        .expect("list_tags over HTTPS should succeed against Docker Hub");
+    assert!(
+        !tags.is_empty(),
+        "expected at least one tag for hello-world"
+    );
+    eprintln!("HTTPS smoke OK: hello-world has {} tags", tags.len());
+}
+
 /// push → pull round-trip through the core is byte-faithful.
 #[test]
 fn test_oci_push_pull_roundtrip() {

--- a/docs/explanation/angreal_init_behaviour.md
+++ b/docs/explanation/angreal_init_behaviour.md
@@ -18,9 +18,17 @@ Functionally this means if you run `angreal init python` at least once the follo
 - `angreal init angreal/python`
 - `angreal init ${HOME}/.angrealrc/python`
 
+A template name that begins with the `oci://` scheme is treated as an OCI
+registry artifact rather than a git remote or local path. Angreal pulls it into
+`${HOME}/.angrealrc/oci/<registry>/<repository>/<tag>/` and renders it. The
+artifact is re-fetched on each run (so a moved tag is honored), mirroring the
+fast-forward-pull behavior used for git templates. See
+[Use OCI Template Targets](/angreal/how-to-guides/use-oci-templates).
+
 ```mermaid
 graph TD;
   A[What does the template name look like]
+  A -->|oci:// scheme| P[Pull artifact into $HOME/.angrealrc/oci, then use the template]
   A -->|Git Remote| B[Does the destination directory exist?]
   A -->|Local File| C[Does the template folder exist at $HOME/.angrealrc ?]
   B -->|Yes| D[Fast forward pull, then use for template.]

--- a/docs/how-to-guides/use-oci-templates.md
+++ b/docs/how-to-guides/use-oci-templates.md
@@ -1,0 +1,126 @@
+---
+title: "Use OCI Template Targets"
+weight: 45
+---
+
+# Use OCI Template Targets
+
+This guide shows how to **consume** a template stored in an OCI registry and how
+to **publish** one, so your templates can be versioned and distributed the same
+way container images and Helm charts are.
+
+Angreal's OCI support is self-contained: it needs no `docker`, `oras`, or
+`skopeo` binary and no running daemon.
+
+## Consume a template
+
+Point `angreal init` at an `oci://` reference:
+
+```bash
+angreal init oci://ghcr.io/acme/py-template:latest
+```
+
+Angreal pulls the artifact, caches it under
+`~/.angrealrc/oci/<registry>/<repository>/<tag>/`, then renders it exactly like
+any other template (prompting for `angreal.toml` values and running `init.py`).
+As with git templates, the artifact is re-fetched on each run so a moved tag is
+always honored.
+
+The `--in-place`, `--force`, and values-file flags work with `oci://` targets
+just as they do for other templates:
+
+```bash
+angreal init oci://ghcr.io/acme/py-template:1.2.0 --in-place
+```
+
+### Private registries
+
+For a private repository, authenticate first. Either `docker login` (angreal
+reads `~/.docker/config.json`):
+
+```bash
+docker login ghcr.io
+angreal init oci://ghcr.io/acme/private-template:latest
+```
+
+…or, from a task, register credentials on an `Oci` client (see below).
+
+## Publish a template
+
+Publishing packages your template directory (the tree containing `angreal.toml`)
+into an OCI artifact and pushes it. Use the `Oci` client from a task or a script:
+
+```python
+import os
+from angreal.integrations.oci import Oci
+
+client = Oci()
+client.login("ghcr.io", os.environ["GHCR_USER"], os.environ["GHCR_TOKEN"])
+client.push("oci://ghcr.io/acme/py-template:1.2.0", "./template")
+```
+
+Anyone can now consume it with `angreal init oci://ghcr.io/acme/py-template:1.2.0`.
+
+### Wrap publishing in a task
+
+```python
+import os
+import angreal
+from angreal.integrations.oci import Oci
+
+@angreal.command(name="publish", about="Publish this template to a registry")
+@angreal.argument(name="version", long="version", takes_value=True, required=True)
+def publish(version: str):
+    """Package ./template and push it as an OCI artifact."""
+    client = Oci()
+    client.login("ghcr.io", os.environ["GHCR_USER"], os.environ["GHCR_TOKEN"])
+    client.push(f"oci://ghcr.io/acme/py-template:{version}", "./template")
+    print(f"published py-template:{version}")
+```
+
+## Inspect available versions
+
+List the tags published for a repository:
+
+```python
+from angreal.integrations.oci import Oci
+
+for tag in Oci().tags("oci://ghcr.io/acme/py-template"):
+    print(tag)
+```
+
+## Try it locally
+
+You can exercise the whole loop against a throwaway registry:
+
+```bash
+# Start a local registry
+docker run -d --rm -p 5000:5000 registry:2
+```
+
+```python
+from angreal.integrations.oci import Oci
+
+client = Oci()
+# Push a local template directory (must contain angreal.toml)
+client.push("oci://localhost:5000/demo/template:v1", "./template")
+```
+
+```bash
+# Consume it
+angreal init oci://localhost:5000/demo/template:v1
+```
+
+## How it is stored
+
+An angreal template artifact is a standard OCI image manifest: a small JSON
+config blob plus a single gzipped-tar layer of the template directory. See the
+[OCI integration reference](/angreal/reference/python-api/integrations/oci) for
+the exact media types — they make artifacts angreal pushes interoperable with
+`oras` and `skopeo`.
+
+## See Also
+
+- [OCI Registry Integration reference](/angreal/reference/python-api/integrations/oci)
+- [Create Templates](/angreal/how-to-guides/create-templates)
+- [angreal init Behavior](/angreal/explanation/angreal_init_behaviour)

--- a/docs/reference/python-api/integrations/index.md
+++ b/docs/reference/python-api/integrations/index.md
@@ -24,3 +24,7 @@ The `angreal.integrations.flox` module provides cross-language development envir
 ### Docker Compose Integration
 
 The `angreal.integrations.docker` module provides Docker container orchestration through Docker Compose. It enables starting, stopping, and managing multi-container applications defined in compose files.
+
+### OCI Registry Integration
+
+The `angreal.integrations.oci` module pulls and pushes angreal templates as OCI artifacts and lists repository tags — daemonless and self-contained. It is the plugin-layer counterpart to consuming templates from the CLI with `angreal init oci://…`.

--- a/docs/reference/python-api/integrations/oci.md
+++ b/docs/reference/python-api/integrations/oci.md
@@ -1,0 +1,206 @@
+---
+title: "OCI Registry Integration"
+weight: 50
+---
+
+# angreal.integrations.oci
+
+Pull and push angreal templates as OCI artifacts, list tags, and authenticate
+against registries — daemonless and self-contained.
+
+## Overview
+
+Angreal's OCI integration talks directly to [OCI](https://opencontainers.org/)
+registries (GHCR, Docker Hub, ECR, Harbor, Zot, a local `registry:2`, …) using a
+pure-Rust client. It is the plugin-layer counterpart to consuming OCI templates
+from the CLI with `angreal init oci://…` — both share the same core, so a
+template you push with `Oci.push()` is one you can render with
+`angreal init oci://…`.
+
+Unlike the [Docker Compose integration](/angreal/reference/python-api/integrations/docker-compose),
+this integration does **not** require a running Docker daemon. It performs
+registry/artifact operations (pull, push, tag listing) over HTTPS.
+
+## Prerequisites
+
+None beyond angreal itself — the OCI client is bundled. To push to (or pull
+from) a private repository you need credentials, supplied either via
+`login()` or an existing Docker `~/.docker/config.json` (e.g. from
+`docker login`).
+
+## Template artifact convention (v1)
+
+An angreal template is stored as a standard OCI image manifest with:
+
+| Component | Media type |
+|-----------|------------|
+| Config blob | `application/vnd.angreal.template.config.v1+json` |
+| Layer | `application/vnd.angreal.template.layer.v1.tar+gzip` |
+
+The layer is a gzipped tar of the template directory — the same tree
+`angreal init` renders. Because it is a spec-compliant manifest, tools like
+`oras` and `skopeo` interoperate with artifacts angreal pushes.
+
+## Classes
+
+### Oci
+
+Client for angreal template artifacts.
+
+```python
+from angreal.integrations.oci import Oci
+
+client = Oci()
+```
+
+#### Constructor
+
+```python
+Oci()
+```
+
+Takes no arguments. Credentials registered with `login()` are held for the
+lifetime of the instance.
+
+#### Instance Methods
+
+##### login
+
+Store Basic credentials for a registry. Credentials set here take precedence
+over Docker `config.json` for that registry, and are used by subsequent
+`pull`/`push`/`tags` calls. No network request is made by `login()` itself.
+
+```python
+def login(registry: str, username: str, password: str) -> None
+```
+
+**Parameters:**
+- `registry` (str): Registry host, e.g. `ghcr.io` or `localhost:5000`.
+- `username` (str): Username.
+- `password` (str): Password or token.
+
+**Example:**
+```python
+import os
+
+client = Oci()
+client.login("ghcr.io", "my-user", os.environ["GHCR_TOKEN"])
+```
+
+##### pull
+
+Pull a template artifact and unpack its layer.
+
+```python
+def pull(reference: str, dest: str | Path = None) -> str
+```
+
+**Parameters:**
+- `reference` (str): Artifact reference, with or without the `oci://` scheme
+  (e.g. `oci://ghcr.io/acme/py-template:latest`).
+- `dest` (str | Path, optional): Destination directory. Defaults to a directory
+  named after the repository (its last path segment) in the current directory.
+
+**Returns:**
+- `str`: The destination path the template was unpacked into.
+
+**Example:**
+```python
+client = Oci()
+path = client.pull("oci://ghcr.io/acme/py-template:latest", "./scaffold")
+print(f"template unpacked to {path}")
+```
+
+##### push
+
+Package a directory as a template artifact and push it.
+
+```python
+def push(reference: str, path: str | Path) -> None
+```
+
+**Parameters:**
+- `reference` (str): Target reference, with or without the `oci://` scheme.
+- `path` (str | Path): Template directory to package (must contain an
+  `angreal.toml`).
+
+**Example:**
+```python
+client = Oci()
+client.push("oci://ghcr.io/acme/py-template:1.2.0", "./my-template")
+```
+
+##### tags
+
+List the tags available for a repository.
+
+```python
+def tags(repository: str) -> list[str]
+```
+
+**Parameters:**
+- `repository` (str): Repository reference (a tag, if present, is ignored),
+  with or without the `oci://` scheme.
+
+**Returns:**
+- `list[str]`: Available tags.
+
+**Example:**
+```python
+client = Oci()
+for tag in client.tags("oci://ghcr.io/acme/py-template"):
+    print(tag)
+```
+
+## Authentication resolution
+
+For each operation, auth is resolved in this order:
+
+1. Credentials registered via `login()` for the reference's registry.
+2. Docker `~/.docker/config.json` credentials for that registry (e.g. after
+   `docker login`).
+3. Anonymous (public repositories).
+
+## Errors
+
+Registry, network, reference-parsing, and packaging failures surface as Python
+`RuntimeError` with a descriptive message.
+
+## Examples
+
+### Publish a template from a task
+
+```python
+import angreal
+from angreal.integrations.oci import Oci
+
+@angreal.command(name="publish", about="Publish this template to GHCR")
+@angreal.argument(name="version", long="version", takes_value=True, required=True)
+def publish(version: str):
+    """Package the template directory and push it as an OCI artifact."""
+    import os
+
+    client = Oci()
+    client.login("ghcr.io", os.environ["GHCR_USER"], os.environ["GHCR_TOKEN"])
+    client.push(f"oci://ghcr.io/acme/py-template:{version}", "./template")
+    print(f"published py-template:{version}")
+```
+
+### Mirror a template between registries
+
+```python
+from angreal.integrations.oci import Oci
+
+client = Oci()
+tmp = client.pull("oci://ghcr.io/acme/py-template:latest", "/tmp/py-template")
+client.push("oci://registry.internal:5000/acme/py-template:latest", tmp)
+```
+
+## See Also
+
+- [Use OCI Template Targets](/angreal/how-to-guides/use-oci-templates) — consume
+  and publish templates end-to-end.
+- [angreal init Behavior](/angreal/explanation/angreal_init_behaviour) — how
+  `angreal init` resolves an `oci://` reference.
+- [Create Templates](/angreal/how-to-guides/create-templates) — authoring the
+  template directory you publish.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - Create Templates: how-to-guides/create-templates.md
     - Include Jinja Templates: how-to-guides/include-jinja-templates.md
     - Install & Configure uv: how-to-guides/install-and-configure-uv.md
+    - Use OCI Template Targets: how-to-guides/use-oci-templates.md
     - Render a Template In Place: how-to-guides/render-template-in-place.md
     - Template System Guide: how-to-guides/template-system-guide.md
     - Use Docker Compose: how-to-guides/use-docker-compose.md
@@ -99,6 +100,7 @@ nav:
         - Git: reference/python-api/integrations/git.md
         - Docker Compose: reference/python-api/integrations/docker-compose.md
         - Flox: reference/python-api/integrations/flox.md
+        - OCI Registry: reference/python-api/integrations/oci.md
       - Templates:
         - reference/python-api/templates/index.md
         - angreal.toml Format: reference/python-api/templates/angreal_toml_format.md

--- a/py_tests/integrations/test_oci.py
+++ b/py_tests/integrations/test_oci.py
@@ -1,0 +1,97 @@
+"""Tests for the angreal.integrations.oci binding.
+
+Import/surface tests always run. The live round-trip is gated on
+ANGREAL_OCI_TEST_REGISTRY (e.g. ``localhost:5555``); spin up a registry with::
+
+    docker run -d --rm -p 5555:5000 registry:2
+    ANGREAL_OCI_TEST_REGISTRY=localhost:5555 angreal test python
+"""
+import os
+
+import pytest
+
+from angreal.integrations.oci import Oci
+
+REGISTRY = os.environ.get("ANGREAL_OCI_TEST_REGISTRY", "").strip()
+requires_registry = pytest.mark.skipif(
+    not REGISTRY, reason="set ANGREAL_OCI_TEST_REGISTRY to run live OCI tests"
+)
+
+
+def test_oci_importable_and_constructs():
+    """The Oci class imports and instantiates."""
+    client = Oci()
+    assert client is not None
+
+
+def test_oci_has_expected_methods():
+    """The minimal surface is present."""
+    client = Oci()
+    for method in ("pull", "push", "tags", "login"):
+        assert hasattr(client, method), f"Oci is missing {method}()"
+
+
+def test_login_accepts_credentials():
+    """login() stores credentials without contacting a registry."""
+    client = Oci()
+    # Should not raise; no network happens until a pull/push/tags call.
+    client.login("ghcr.io", "user", "token")
+
+
+def test_pull_invalid_reference_raises():
+    """A malformed reference surfaces as a Python exception, not a crash."""
+    client = Oci()
+    with pytest.raises(Exception):
+        client.pull("not a valid reference !!")
+
+
+def _make_template(root):
+    """Create a minimal valid angreal template under ``root``; return its path."""
+    template = os.path.join(root, "template")
+    inner = os.path.join(template, "{{ folder_variable }}")
+    os.makedirs(os.path.join(inner, ".angreal"))
+    with open(os.path.join(template, "angreal.toml"), "w") as f:
+        f.write('folder_variable = "oci_py_rendered"\n')
+    with open(os.path.join(inner, "README.rst"), "w") as f:
+        f.write("# {{ folder_variable }}\n")
+    with open(os.path.join(inner, ".angreal", "init.py"), "w") as f:
+        f.write("def init():\n    pass\n")
+    return template
+
+
+@requires_registry
+def test_push_pull_tags_roundtrip(tmp_path):
+    """push -> tags -> pull round-trips through a live registry."""
+    client = Oci()
+    template = _make_template(str(tmp_path))
+    reference = f"oci://{REGISTRY}/angreal-py-test/roundtrip:v1"
+
+    client.push(reference, template)
+
+    tags = client.tags(f"oci://{REGISTRY}/angreal-py-test/roundtrip")
+    assert "v1" in tags
+
+    dest = tmp_path / "pulled"
+    out = client.pull(reference, str(dest))
+    assert os.path.isdir(out)
+    assert os.path.isfile(os.path.join(out, "angreal.toml"))
+    assert os.path.isfile(
+        os.path.join(out, "{{ folder_variable }}", "README.rst")
+    )
+
+
+@requires_registry
+def test_pull_defaults_dest_to_repo_basename(tmp_path, monkeypatch):
+    """pull() with no dest lands in a cwd dir named after the repo."""
+    client = Oci()
+    template = _make_template(str(tmp_path))
+    reference = f"oci://{REGISTRY}/angreal-py-test/defaultdest:v1"
+    client.push(reference, template)
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    out = client.pull(reference)
+    assert os.path.basename(out) == "defaultdest"
+    assert os.path.isfile(os.path.join(out, "angreal.toml"))


### PR DESCRIPTION
## Summary

Implements the "We should support OCI" feature request (**ANG-I-0010**) in the two intended forms, over one shared pure-Rust core (`oci-client`, async contained behind a per-op current-thread tokio runtime):

1. **OCI template targets** — `angreal init oci://<registry>/<repo>:<tag>` pulls a template artifact into `~/.angrealrc/oci/<registry>/<repo>/<tag>/` and renders it through the existing pipeline. `get_scheme` short-circuits `oci://` before git-URL parsing; the artifact is re-fetched each run so moved tags are honored (mirrors git ff-pull).
2. **OCI plugin interface** — `angreal.integrations.oci.Oci` exposes `pull` / `push` / `tags` / `login` for task authors, mirroring the git/flox/venv bindings.

## Template artifact convention (v1)

A standard OCI image manifest with a JSON config blob (`application/vnd.angreal.template.config.v1+json`) plus a gzipped-tar layer (`application/vnd.angreal.template.layer.v1.tar+gzip`) of the template dir — so `oras`/`skopeo` interoperate. Auth resolves `login()` creds → Docker `config.json` → anonymous.

## One TLS backend (not two)

`oci-client`'s default is `rustls-tls` (pulls in rustls + aws-lc-rs). It's pinned to `native-tls` (`default-features = false`) so it shares the **vendored OpenSSL already in the tree**. `cargo tree -i rustls` / `aws-lc-rs` → absent.

## Test-infra fix (called out separately)

Adds `crates/angreal/build.rs` (+ `pyo3-build-config` build-dependency) that emits the Python rpath from pyo3's resolved config. Fixes the pre-existing macOS `dyld … Python3.framework … no LC_RPATH` abort so `cargo test` binaries (pyo3 `auto-initialize`) load libpython locally — no `DYLD_*`/`PYO3_PYTHON` hacks. General improvement, surfaced by this work (pattern from `cloacina`).

## Testing

- **Rust unit** (113 pass): media types, auth default, reference parse/strip + cache-path helpers, pack/unpack round-trip, `oci://` scheme detection.
- **Integration** (gated on `ANGREAL_OCI_TEST_REGISTRY`): push→pull round-trip + full `init("oci://…")` e2e — **verified live** against `registry:2`.
- **Python functional** (255 pass): import/surface, login, invalid-ref, and live push→tags→pull round-trip + default-dest.

Generated `docs/api/**` is intentionally excluded (the docs pipeline regenerates it; committing it here would add unrelated Plissken-version churn). Hand-authored how-to + reference + nav are included; `angreal docs build` (strict) passes.