### PR TITLE
feat(oci): --insecure flag for pulling from plain-HTTP registries

### DIFF
--- a/crates/angreal/src/builder/mod.rs
+++ b/crates/angreal/src/builder/mod.rs
@@ -66,6 +66,15 @@ fn add_init_subcommand(app: App<'static>) -> App<'static> {
                     .takes_value(true)
                     .help("Provide Values to template, bypassing template toml."),
             )
+            .arg(
+                Arg::new("insecure")
+                    .long("--insecure")
+                    .takes_value(false)
+                    .help(
+                        "Allow pulling an oci:// template from a plain-HTTP registry \
+                         (e.g. a self-hosted registry without TLS).",
+                    ),
+            )
             .arg(Arg::new("template").takes_value(true).required(true).help(
                 "The template to use. Either a pre-downloaded template name, or url to a git repo.",
             )),

--- a/crates/angreal/src/init.rs
+++ b/crates/angreal/src/init.rs
@@ -30,6 +30,7 @@ pub fn init(
     take_inputs: bool,
     values_file: Option<&str>,
     in_place: bool,
+    insecure: bool,
 ) {
     let angreal_home = create_home_dot_angreal();
     let template_type = get_scheme(template).unwrap();
@@ -44,7 +45,7 @@ pub fn init(
             handle_git_template(template, angreal_home)
         }
         "file" => PathBuf::from(handle_file_template(template, &angreal_home)),
-        "oci" => handle_oci_template(template, &angreal_home),
+        "oci" => handle_oci_template(template, &angreal_home, insecure),
         &_ => {
             error!(
                 "Unhandled template type {} from {}, exiting.",
@@ -262,7 +263,7 @@ fn handle_git_template(template: &str, angreal_home: PathBuf) -> PathBuf {
 /// git templates (which ff-pull), the artifact is re-fetched each run so a moved
 /// tag is honored; the cache dir is cleared first to avoid mixing in stale files
 /// from a previous pull of the same tag.
-fn handle_oci_template(template: &str, angreal_home: &Path) -> PathBuf {
+fn handle_oci_template(template: &str, angreal_home: &Path, insecure: bool) -> PathBuf {
     use crate::integrations::oci;
 
     let subpath = match oci::cache_subpath(template) {
@@ -283,7 +284,7 @@ fn handle_oci_template(template: &str, angreal_home: &Path) -> PathBuf {
     }
 
     debug!("Pulling OCI template {} into {:?}", template, dst);
-    match oci::Oci::pull_artifact(template, &dst, &oci::resolve_auth(template)) {
+    match oci::Oci::pull_artifact(template, &dst, &oci::resolve_auth(template), insecure) {
         Ok(path) => path,
         Err(e) => {
             error!("Failed to pull OCI template {}: {}", template, e);

--- a/crates/angreal/src/integrations/oci/mod.rs
+++ b/crates/angreal/src/integrations/oci/mod.rs
@@ -71,10 +71,17 @@ impl Oci {
     /// Pull a template artifact and unpack its layer into `dest`.
     ///
     /// Accepts a bare reference (`registry/repo:tag`) or one with an `oci://`
-    /// scheme prefix. Returns the destination path on success.
-    pub fn pull_artifact(reference: &str, dest: &Path, auth: &OciAuth) -> Result<PathBuf> {
+    /// scheme prefix. When `insecure` is set, the registry is contacted over
+    /// plain HTTP (for self-hosted registries without TLS). Returns the
+    /// destination path on success.
+    pub fn pull_artifact(
+        reference: &str,
+        dest: &Path,
+        auth: &OciAuth,
+        insecure: bool,
+    ) -> Result<PathBuf> {
         let reference = parse_reference(reference)?;
-        let client = build_client(&reference);
+        let client = build_client(&reference, insecure);
         let registry_auth = auth.to_registry_auth();
 
         let image_data = run_async(async {
@@ -108,8 +115,14 @@ impl Oci {
     }
 
     /// Package `src_dir` as an angreal template artifact and push it to
-    /// `reference`.
-    pub fn push_artifact(reference: &str, src_dir: &Path, auth: &OciAuth) -> Result<()> {
+    /// `reference`. When `insecure` is set, the registry is contacted over plain
+    /// HTTP.
+    pub fn push_artifact(
+        reference: &str,
+        src_dir: &Path,
+        auth: &OciAuth,
+        insecure: bool,
+    ) -> Result<()> {
         if !src_dir.is_dir() {
             bail!(
                 "cannot push OCI template: '{}' is not a directory",
@@ -118,7 +131,7 @@ impl Oci {
         }
 
         let reference = parse_reference(reference)?;
-        let client = build_client(&reference);
+        let client = build_client(&reference, insecure);
         let registry_auth = auth.to_registry_auth();
 
         let tar_gz = pack_targz(src_dir).with_context(|| {
@@ -145,10 +158,11 @@ impl Oci {
         Ok(())
     }
 
-    /// List the tags available for a repository.
-    pub fn list_tags(repository: &str, auth: &OciAuth) -> Result<Vec<String>> {
+    /// List the tags available for a repository. When `insecure` is set, the
+    /// registry is contacted over plain HTTP.
+    pub fn list_tags(repository: &str, auth: &OciAuth, insecure: bool) -> Result<Vec<String>> {
         let reference = parse_reference(repository)?;
-        let client = build_client(&reference);
+        let client = build_client(&reference, insecure);
         let registry_auth = auth.to_registry_auth();
 
         let response = run_async(async {
@@ -250,13 +264,19 @@ fn parse_reference(reference: &str) -> Result<Reference> {
         .map_err(|e| anyhow!("invalid OCI reference '{reference}': {e}"))
 }
 
-/// Build a client for the given reference. Registries on `localhost` /
-/// `127.0.0.1` are contacted over plain HTTP (test registries); everything else
-/// uses HTTPS, riding the vendored-OpenSSL native-tls backend already in the
-/// tree.
-fn build_client(reference: &Reference) -> Client {
+/// Whether to talk to `registry` over plain HTTP: always for `localhost` /
+/// `127.0.0.1` (test/loopback registries), or when the caller opts into
+/// `insecure` (a self-hosted registry without TLS).
+fn use_http_for(registry: &str, insecure: bool) -> bool {
+    insecure || registry.starts_with("localhost") || registry.starts_with("127.0.0.1")
+}
+
+/// Build a client for the given reference. HTTPS by default, riding the
+/// vendored-OpenSSL native-tls backend already in the tree; plain HTTP for
+/// loopback registries or when `insecure` is set.
+fn build_client(reference: &Reference, insecure: bool) -> Client {
     let registry = reference.registry();
-    let protocol = if registry.starts_with("localhost") || registry.starts_with("127.0.0.1") {
+    let protocol = if use_http_for(registry, insecure) {
         ClientProtocol::HttpsExcept(vec![registry.to_string()])
     } else {
         ClientProtocol::Https
@@ -346,6 +366,17 @@ mod tests {
     #[test]
     fn is_available_is_true() {
         assert!(Oci::is_available());
+    }
+
+    #[test]
+    fn use_http_for_loopback_and_insecure() {
+        // Loopback registries are always plain HTTP.
+        assert!(use_http_for("localhost:5000", false));
+        assert!(use_http_for("127.0.0.1:5000", false));
+        // Real registries are HTTPS unless the caller opts into insecure.
+        assert!(!use_http_for("ghcr.io", false));
+        assert!(use_http_for("ghcr.io", true));
+        assert!(use_http_for("registry.internal:5000", true));
     }
 
     #[test]

--- a/crates/angreal/src/lib.rs
+++ b/crates/angreal/src/lib.rs
@@ -556,6 +556,7 @@ fn main(py: Python<'_>) -> PyResult<()> {
                 None
             },
             _sub_matches.is_present("in_place"),
+            _sub_matches.is_present("insecure"),
         ),
         Some(("_complete", _sub_matches)) => {
             // Hidden command for shell completion

--- a/crates/angreal/src/python_bindings/integrations/oci.rs
+++ b/crates/angreal/src/python_bindings/integrations/oci.rs
@@ -69,9 +69,10 @@ impl PyOci {
     }
 
     /// Pull a template artifact to `dest` (default: a directory named after the
-    /// repository, under the current directory). Returns the destination path.
-    #[pyo3(signature = (reference, dest=None))]
-    fn pull(&self, reference: &str, dest: Option<PathBuf>) -> PyResult<String> {
+    /// repository, under the current directory). Set `insecure=True` to pull
+    /// from a plain-HTTP registry. Returns the destination path.
+    #[pyo3(signature = (reference, dest=None, insecure=false))]
+    fn pull(&self, reference: &str, dest: Option<PathBuf>, insecure: bool) -> PyResult<String> {
         let dest = match dest {
             Some(d) => d,
             None => {
@@ -80,21 +81,24 @@ impl PyOci {
             }
         };
         let auth = self.auth_for(reference);
-        let out = Oci::pull_artifact(reference, &dest, &auth).map_err(to_pyerr)?;
+        let out = Oci::pull_artifact(reference, &dest, &auth, insecure).map_err(to_pyerr)?;
         Ok(out.display().to_string())
     }
 
     /// Package the directory at `path` as a template artifact and push it to
-    /// `reference`.
-    fn push(&self, reference: &str, path: PathBuf) -> PyResult<()> {
+    /// `reference`. Set `insecure=True` to push to a plain-HTTP registry.
+    #[pyo3(signature = (reference, path, insecure=false))]
+    fn push(&self, reference: &str, path: PathBuf, insecure: bool) -> PyResult<()> {
         let auth = self.auth_for(reference);
-        Oci::push_artifact(reference, &path, &auth).map_err(to_pyerr)
+        Oci::push_artifact(reference, &path, &auth, insecure).map_err(to_pyerr)
     }
 
-    /// List the tags available for `repository`.
-    fn tags(&self, repository: &str) -> PyResult<Vec<String>> {
+    /// List the tags available for `repository`. Set `insecure=True` for a
+    /// plain-HTTP registry.
+    #[pyo3(signature = (repository, insecure=false))]
+    fn tags(&self, repository: &str, insecure: bool) -> PyResult<Vec<String>> {
         let auth = self.auth_for(repository);
-        Oci::list_tags(repository, &auth).map_err(to_pyerr)
+        Oci::list_tags(repository, &auth, insecure).map_err(to_pyerr)
     }
 }
 

--- a/crates/angreal/tests/integration/init.rs
+++ b/crates/angreal/tests/integration/init.rs
@@ -12,6 +12,7 @@ fn test_init_from_git() {
         false,
         None,
         false,
+        false,
     );
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));
@@ -29,6 +30,7 @@ fn test_init_long() {
         false,
         None,
         false,
+        false,
     );
     // clean up rendered
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -36,7 +38,14 @@ fn test_init_long() {
     let _ = fs::remove_dir_all(&rendered_root);
     // use the long version
 
-    init("angreal/angreal_test_template", true, false, None, false);
+    init(
+        "angreal/angreal_test_template",
+        true,
+        false,
+        None,
+        false,
+        false,
+    );
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));
     let _ = fs::remove_dir_all(&rendered_root);
@@ -55,13 +64,21 @@ fn test_init_values() {
         false,
         values_toml.to_str(),
         false,
+        false,
     );
     // clean up rendered
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("folder_name"));
     let _ = fs::remove_dir_all(&rendered_root);
     // use the long version
-    init("angreal/angreal_test_template", true, false, None, false);
+    init(
+        "angreal/angreal_test_template",
+        true,
+        false,
+        None,
+        false,
+        false,
+    );
 
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));
@@ -72,7 +89,7 @@ fn test_init_values() {
 #[test]
 fn test_init_short() {
     // clone
-    init("angreal_test_template", true, false, None, false);
+    init("angreal_test_template", true, false, None, false, false);
 
     let mut rendered_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     rendered_root.push(Path::new("angreal_test_project"));

--- a/crates/angreal/tests/integration/oci.rs
+++ b/crates/angreal/tests/integration/oci.rs
@@ -77,7 +77,7 @@ fn test_https_public_registry_smoke() {
         return;
     }
 
-    let tags = Oci::list_tags("docker.io/library/hello-world", &OciAuth::Anonymous)
+    let tags = Oci::list_tags("docker.io/library/hello-world", &OciAuth::Anonymous, false)
         .expect("list_tags over HTTPS should succeed against Docker Hub");
     assert!(
         !tags.is_empty(),
@@ -98,11 +98,11 @@ fn test_oci_push_pull_roundtrip() {
     let template = make_template(&tmp);
 
     let reference = format!("oci://{registry}/angreal-test/roundtrip:v1");
-    Oci::push_artifact(&reference, &template, &OciAuth::Anonymous)
+    Oci::push_artifact(&reference, &template, &OciAuth::Anonymous, false)
         .expect("push should succeed against the test registry");
 
     let dest = tmp.join("pulled");
-    let out = Oci::pull_artifact(&reference, &dest, &oci::resolve_auth(&reference))
+    let out = Oci::pull_artifact(&reference, &dest, &oci::resolve_auth(&reference), false)
         .expect("pull should succeed");
 
     assert_eq!(out, dest);
@@ -128,7 +128,7 @@ fn test_init_from_oci() {
     let template = make_template(&tmp);
 
     let reference = format!("oci://{registry}/angreal-test/init:v1");
-    Oci::push_artifact(&reference, &template, &OciAuth::Anonymous)
+    Oci::push_artifact(&reference, &template, &OciAuth::Anonymous, false)
         .expect("push should succeed against the test registry");
 
     // init() renders relative to the process cwd; render into an isolated temp.
@@ -137,7 +137,7 @@ fn test_init_from_oci() {
     let original = env::current_dir().unwrap();
     env::set_current_dir(&cwd).unwrap();
 
-    init(&reference, true, false, None, false);
+    init(&reference, true, false, None, false, false);
 
     env::set_current_dir(&original).unwrap();
 

--- a/docs/how-to-guides/use-oci-templates.md
+++ b/docs/how-to-guides/use-oci-templates.md
@@ -45,6 +45,19 @@ angreal init oci://ghcr.io/acme/private-template:latest
 
 …or, from a task, register credentials on an `Oci` client (see below).
 
+### Self-hosted / plain-HTTP registries
+
+By default angreal pulls over HTTPS. `localhost` and `127.0.0.1` registries are
+automatically treated as plain HTTP. For any other registry served without TLS
+(e.g. a self-hosted registry on your network), pass `--insecure`:
+
+```bash
+angreal init oci://registry.internal:5000/acme/py-template:latest --insecure
+```
+
+From a task, the `Oci` client methods take an `insecure=True` keyword for the
+same effect (`pull`, `push`, `tags`).
+
 ## Publish a template
 
 Publishing packages your template directory (the tree containing `angreal.toml`)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -54,13 +54,14 @@ angreal init <TEMPLATE> [OPTIONS]
 ```
 
 **Arguments:**
-- `TEMPLATE` - Template source (local path, Git URL, or GitHub shorthand)
+- `TEMPLATE` - Template source (local path, Git URL, GitHub shorthand, or OCI reference `oci://...`)
 
 **Options:**
 - `-f, --force` - Force the rendering of a template, even if paths/files already exist
 - `-d, --defaults` - Use default values provided in the angreal.toml
 - `-i, --in-place` - Render the template's contents into the current directory, stripping the template's top-level directory
 - `--values <FILE>` - Provide values to template, bypassing template toml
+- `--insecure` - Allow pulling an `oci://` template from a plain-HTTP registry (self-hosted registry without TLS)
 
 **Template Sources & Examples:**
 


### PR DESCRIPTION
## Summary

Follow-up to #139 (ANG-I-0010). Adds an **`--insecure`** opt-in for pulling `oci://` templates from a registry served without TLS (self-hosted registries beyond localhost).

- CLI: `angreal init oci://registry.internal:5000/org/name:tag --insecure`
- Binding: `Oci.pull(ref, dest, insecure=True)` (also on `push`/`tags`)

By default angreal pulls over HTTPS; `localhost`/`127.0.0.1` are auto-treated as plain HTTP. `--insecure` extends that to any registry.

## Scope

**Consumption-only.** This deliberately does **not** add a CLI `push`/publish surface — angreal isn't an artifact manager. Push stays a binding-layer primitive (`Oci.push()`), as merged in #139.

Idea credited to @jasonm-swish's parallel `feat/DSO-oci-init-support` branch (from which we took only the consumption-side `--insecure`, not the CLI push / task-bundle surface).

## Implementation

Flag flows `builder/mod.rs` → `lib.rs` → `init::init` → `handle_oci_template` → `Oci::pull_artifact`. The core factors the HTTP-vs-HTTPS decision into a small pure, unit-tested `use_http_for(registry, insecure)`. `insecure` threaded through the core (`pull_artifact`/`push_artifact`/`list_tags`) and the Python binding (default `False`).

## Testing (dogfooded via angreal tasks)

- `angreal test rust --unit-only` → 114 passed, incl. new `use_http_for_loopback_and_insecure`.
- `angreal test rust --integration-only --filter oci::` → init e2e + push/pull round-trip pass (live `registry:2`).
- `angreal test python` → 255 passed; binding rebuilt with the new `insecure` params, all 6 OCI tests incl. live round-trip.
- `angreal docs build` (strict) → exit 0.