### PR TITLE
Release 2.9.0: OCI support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "angreal",
       "source": "./plugin",
       "description": "Task automation skills for angreal projects. Focused skills for running tasks, authoring tasks, arguments, ToolDescriptions, project setup, creating templates, and development patterns.",
-      "version": "2.8.6"
+      "version": "2.9.0"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "angreal"
-version = "2.8.8"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 default-members = ["crates/angreal"]
 
 [workspace.package]
-version = "2.8.8"
+version = "2.9.0"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/angreal/angreal"

--- a/crates/angreal/Cargo.toml
+++ b/crates/angreal/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/angreal/angreal"
 license = "GPL-3.0-only"
 name = "angreal"
 repository = "https://github.com/angreal/angreal"
-version = "2.8.8"
+version = "2.9.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "angreal",
-  "version": "2.8.8",
+  "version": "2.9.0",
   "description": "Task automation skills for angreal projects. Focused skills for running tasks, authoring tasks, arguments, ToolDescriptions, project setup, creating templates, and development patterns.",
   "author": {
     "name": "angreal",


### PR DESCRIPTION
## Release 2.9.0

Version bump only (2.8.8 → 2.9.0) across workspace `Cargo.toml`, `crates/angreal/Cargo.toml`, `plugin/.claude-plugin/plugin.json`, and `Cargo.lock`.

### What's in 2.9.0 (merged since 2.8.8)

- **OCI template targets** (#139) — `angreal init oci://<registry>/<repo>:<tag>` pulls a template artifact and renders it.
- **`angreal.integrations.oci`** (#139) — daemonless OCI binding for task authors: `pull` / `push` / `tags` / `login`.
- **`--insecure`** (#140) — pull `oci://` templates from plain-HTTP / self-hosted registries.
- **Tooling**: `build.rs` pyo3 Python-rpath fix (local macOS `cargo test`), CI `registry:2` service for OCI round-trips, and a blocking macOS HTTPS (SecureTransport) smoke gate.

Minor bump (semver): new user-facing features, no breaking changes.

On merge + green, a GitHub Release `v2.9.0` will be published to trigger wheel builds (macОS/Linux/Windows/musl) and PyPI + cargo publish.